### PR TITLE
Add scoped CSS feature & tests

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -264,7 +264,7 @@ const someProps = {
 
 // Full Astro Component Syntax:
 // https://docs.astro.build/core-concepts/astro-components/`,
-				styles: []string{":global(:root.astro-HMNNHVCQ ){font-family:system-ui;padding:2em 0;}:global(.counter.astro-HMNNHVCQ ){display:grid;grid-template-columns:repeat(3,minmax(0,1fr));place-items:center;font-size:2em;margin-top:2em;}:global(.children.astro-HMNNHVCQ ){display:grid;place-items:center;margin-bottom:2em;}"},
+				styles: []string{":root{font-family:system-ui;padding:2em 0;}.counter{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));place-items:center;font-size:2em;margin-top:2em;}.children{display:grid;place-items:center;margin-bottom:2em;}"},
 				code: `<html lang="en">
   <head>
     <meta charset="utf-8">

--- a/internal/token.go
+++ b/internal/token.go
@@ -437,7 +437,7 @@ loop:
 	for {
 		c := z.readByte()
 		if z.err != nil {
-			fmt.Printf("Unexpected character in loop: %v\n", string(c))
+			fmt.Printf("Unexpected character in loop: \"%v\"\n", string(c))
 			break loop
 		}
 		if c != '<' {

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"bytes"
+	"strings"
 
 	// "strings"
 
@@ -10,52 +11,226 @@ import (
 	a "golang.org/x/net/html/atom"
 )
 
+// Take a slice of DOM nodes, and scope CSS within every <style> tag
 func ScopeStyle(styles []*tycho.Node, opts TransformOptions) {
 	for _, n := range styles {
-		if n.DataAtom == a.Style {
-			n.Attr = append(n.Attr, tycho.Attribute{
-				Key: "data-astro-id",
-				Val: opts.Scope,
-			})
-			p := css.NewParser(bytes.NewBufferString(n.FirstChild.Data), false)
-			out := ""
-			for {
-				gt, _, data := p.Next()
-				if gt == css.ErrorGrammar {
-					break
-				} else if gt == css.AtRuleGrammar || gt == css.BeginAtRuleGrammar || gt == css.BeginRulesetGrammar || gt == css.DeclarationGrammar {
-					out += string(data)
-					if gt == css.DeclarationGrammar {
-						out += ":"
-					}
-					for _, val := range p.Values() {
-						if gt == css.BeginRulesetGrammar && val.TokenType == css.IdentToken {
-							out += scopeRule(string(val.Data), opts) + " "
-						} else {
-							out += string(val.Data)
-						}
-					}
-					if gt == css.BeginAtRuleGrammar || gt == css.BeginRulesetGrammar {
-						out += "{"
-					} else if gt == css.AtRuleGrammar || gt == css.DeclarationGrammar {
-						out += ";"
-					}
+		if n.DataAtom != a.Style {
+			continue
+		}
+		n.Attr = append(n.Attr, tycho.Attribute{
+			Key: "data-astro-id",
+			Val: opts.Scope,
+		})
+		p := css.NewParser(bytes.NewBufferString(n.FirstChild.Data), false)
+		out := ""
+
+		isKeyframes := false    // if we’re inside @keyframes, there’s nothing to scope
+		keyframeCurlyCount := 0 // keep track of open "{"s inside @keyframes
+
+	walk:
+		for {
+			gt, _, data := p.Next()
+
+			switch gt {
+			case css.ErrorGrammar:
+				if len(string(data)) > 0 {
+					out += string(data) // this will happen for invalid or unexpected CSS. Try and retain output as much as possible without throwing
 				} else {
-					if gt == css.QualifiedRuleGrammar {
-						for _, val := range p.Values() {
-							out += scopeRule(string(val.Data), opts) + ", "
+					break walk // an unrecoverable error occurred, or the end has been reached
+				}
+			case css.EndAtRuleGrammar,
+				css.EndRulesetGrammar:
+				out += "}"
+			case
+				css.BeginAtRuleGrammar,
+				css.BeginRulesetGrammar,
+				css.DeclarationGrammar,
+				css.QualifiedRuleGrammar:
+
+				// prelude
+				switch gt {
+				case css.AtRuleGrammar,
+					css.BeginAtRuleGrammar:
+					out += string(data)
+					if string(data) == "@keyframes" {
+						isKeyframes = true
+						keyframeCurlyCount = 0
+					}
+				case css.DeclarationGrammar:
+					out += string(data) + ":"
+				default:
+				}
+
+				// main selector
+				parenCount := 0          // keeps track of open parens. scoping can’t happen inside parens (:not(), :where(), etc.)
+				isBracket := false       // keeps track of attr brackets (can’t nest like parens, so it’s simply ”open”/“close”)
+				isGlobal := false        // keeps track of :global() function (no scope, and omit from output)
+				isElement := true        // keeps track of base element selectors (e.g. body, h1). Elements must be assumed ("true") until ".", "#", etc. are encountered
+				isGlobalElement := false // keeps track of <body>, <html>, and other protected elements (isElement will always be true as well)
+				isPseudoState := false   // keeps track of pseudo state/element context (i.e. ensures :hover or ::before don’t get scoped). This is "false" until ":" is encountered
+				nextValues := p.Values()
+				for n, val := range nextValues {
+					strVal := string(val.Data)
+
+					// if inside @keyframes, don’t transform what’s there
+					if isKeyframes {
+						out += strVal
+						continue
+					}
+
+					switch strVal {
+					case ".",
+						"#":
+						isPseudoState = false
+						isElement = false
+						out += strVal
+					case ":":
+						isPseudoState = true
+						// look ahead to see if this is the start of ":global(".
+						// If so, omit from output and start global state
+						if len(nextValues) > n+1 && string(nextValues[n+1].Data) == "global(" {
+							isGlobal = true
+						} else {
+							// if not the start of ":global(", then include in output
+							out += strVal
 						}
-					} else {
-						out += string(data)
+					case "global(":
+						parenCount++
+						// omit from output
+					case "(":
+						parenCount++
+						out += strVal
+						isElement = true
+						isPseudoState = false
+					case ")":
+						parenCount--
+						if !isGlobal || parenCount != 0 {
+							out += strVal // output only if this doesn’t close ":global("
+						}
+					case "[":
+						isBracket = true
+						isElement = false
+						isPseudoState = false
+						// if there is no selector before an attribute selector, then assume "*"
+						if n == 0 {
+							out += scopeRule("", opts)
+						}
+						out += strVal
+					case "]":
+						isBracket = false
+						out += strVal
+					case "{":
+						keyframeCurlyCount++
+						isElement = true
+						isPseudoState = false
+						out += strVal
+					case "}":
+						keyframeCurlyCount--
+						if keyframeCurlyCount == 0 {
+							isKeyframes = false
+						}
+						out += strVal
+					case "*":
+						if !isGlobal {
+							out += scopeRule("", opts) // turns "*" into ".astro-XXXXXX" rather than "*.astro-XXXXXX"
+						} else {
+							out += strVal
+						}
+					default:
+						// handle IDs with parens attached
+						if strings.Contains(strVal, "(") {
+							parenCount++ // if new paren opened, count it
+							isElement = true
+							isPseudoState = false
+						}
+
+						// if this is an element, check if it’s <body>, etc.
+						if isElement && globalElement(strVal) {
+							isGlobalElement = true
+						}
+
+						// whitespace tokens are used to reset chained classes and functions
+						if val.TokenType == css.WhitespaceToken {
+							// important: global elements like <body> may have classes that should not be scoped
+							if isElement && isGlobalElement {
+								isGlobalElement = false
+							}
+
+							// important: :global() might be chained (:global().some-class)
+							// so keep it active until whitespace is reached after final paren
+							if isGlobal && parenCount == 0 {
+								isGlobal = false
+							}
+						}
+
+						// scope class
+						if gt == css.BeginRulesetGrammar && val.TokenType == css.IdentToken && // only scope scope-able tokens
+							!isPseudoState && // don’t scope pseudostates
+							!isGlobal && // don’t scope in :global() scope
+							!isGlobalElement &&
+							!isBracket && // don’t scope within element brackets
+							parenCount == 0 { // don’t scope within parens like :not()
+							out += scopeRule(strVal, opts)
+						} else {
+							// otherwise, append output
+							out += strVal
+						}
+
+						// reset state
+						isElement = true
+						isPseudoState = false
 					}
 				}
+
+				// generate tail of next rule
+				switch gt {
+				case css.BeginAtRuleGrammar,
+					css.BeginRulesetGrammar:
+					out += "{"
+				case css.DeclarationGrammar,
+					css.EndRulesetGrammar,
+					css.EndAtRuleGrammar:
+					out += ";"
+				case css.QualifiedRuleGrammar:
+					out += ","
+				}
+			default:
+				out += string(data)
+				for _, val := range p.Values() {
+					strVal := string(val.Data)
+					out += strVal
+				}
+				out += ";"
 			}
-			n.FirstChild.Data = out
 		}
+		n.FirstChild.Data = out
 	}
 }
 
-func scopeRule(rule string, opts TransformOptions) string {
-	scope := ".astro-" + opts.Scope
-	return rule + scope
+// Turn ".foo" into ".foo.astro-XXXXXX"
+func scopeRule(id string, opts TransformOptions) string {
+	return id + ".astro-" + opts.Scope
+}
+
+// Get list of elements that should be scoped
+func globalElement(id string) bool {
+	switch id {
+	case "base",
+		"body",
+		"font",
+		"frame",
+		"frameset",
+		"head",
+		"html",
+		"link",
+		"meta",
+		"noframes",
+		"noscript",
+		"script",
+		"style",
+		"title":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -1,0 +1,199 @@
+package transform
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tycho "github.com/snowpackjs/astro/internal"
+	"github.com/snowpackjs/astro/internal/test_utils"
+)
+
+func TestScopeStyle(t *testing.T) {
+	// note: the tests have hashes inlined because it’s easier to read
+	// note: this must be valid CSS, hence the empty "{}"
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "class",
+			source: ".class{}",
+			want:   ".class.astro-XXXXXX{}",
+		},
+		{
+			name:   "element",
+			source: "h1{}",
+			want:   "h1.astro-XXXXXX{}",
+		},
+		{
+			name:   "adjacent sibling",
+			source: ".class+.class{}",
+			want:   ".class.astro-XXXXXX+.class.astro-XXXXXX{}",
+		},
+		{
+			name:   "children universal",
+			source: ".class *{}",
+			want:   ".class.astro-XXXXXX .astro-XXXXXX{}",
+		},
+		{
+			name:   "attr",
+			source: "a[aria-current=\"page\"]{}",
+			want:   "a.astro-XXXXXX[aria-current=\"page\"]{}",
+		},
+		{
+			name:   "attr universal implied",
+			source: "[aria-visible],[aria-hidden]{}",
+			want:   ".astro-XXXXXX[aria-visible],.astro-XXXXXX[aria-hidden]{}",
+		},
+		{
+			name:   "universal pseudo state",
+			source: "*:hover{}",
+			want:   ".astro-XXXXXX:hover{}",
+		},
+		{
+			name:   "immediate child universal",
+			source: ".class>*{}",
+			want:   ".class.astro-XXXXXX>.astro-XXXXXX{}",
+		},
+		{
+			name:   "element + pseudo state",
+			source: ".class button:focus{}",
+			want:   ".class.astro-XXXXXX button.astro-XXXXXX:focus{}",
+		},
+		{
+			name:   "element + pseudo element",
+			source: ".class h3::before{}",
+			want:   ".class.astro-XXXXXX h3.astro-XXXXXX::before{}",
+		},
+		{
+			name:   "media query",
+			source: "@media screen and (min-width:640px){.class{}}",
+			want:   "@media screen and (min-width:640px){.class.astro-XXXXXX{}}",
+		},
+		{
+			name:   "element + pseudo state + pseudo element",
+			source: "button:focus::before{}",
+			want:   "button.astro-XXXXXX:focus::before{}",
+		},
+		{
+			name:   "global children",
+			source: ".class :global(ul li){}",
+			want:   ".class.astro-XXXXXX ul li{}",
+		},
+		{
+			name:   "global universal",
+			source: ".class :global(*){}",
+			want:   ".class.astro-XXXXXX *{}",
+		},
+		{
+			name:   "global with scoped children",
+			source: ":global(section) .class{}",
+			want:   "section .class.astro-XXXXXX{}",
+		},
+		{
+			name:   "subsequent siblings + global",
+			source: ".class~:global(a){}",
+			want:   ".class.astro-XXXXXX~a{}",
+		},
+		{
+			name:   "global nested parens",
+			source: ".class :global(.nav:not(.is-active)){}",
+			want:   ".class.astro-XXXXXX .nav:not(.is-active){}",
+		},
+		{
+			name:   "global nested parens + chained class",
+			source: ":global(body:not(.is-light)).is-dark,:global(body:not(.is-dark)).is-light{}",
+			want:   "body:not(.is-light).is-dark,body:not(.is-dark).is-light{}",
+		},
+		{
+			name:   "global chaining global",
+			source: ":global(.foo):global(.bar){}",
+			want:   ".foo.bar{}",
+		},
+		{
+			name:   "class chained global",
+			source: ".class:global(.bar){}",
+			want:   ".class.astro-XXXXXX.bar{}", // technically this may be incorrect, but would require a lookahead to fix
+		},
+		{
+			name:   "chained :not()",
+			source: ".class:not(.is-active):not(.is-disabled){}",
+			want:   ".class.astro-XXXXXX:not(.is-active):not(.is-disabled){}",
+		},
+		{
+			name:   "weird chaining",
+			source: ":hover.a:focus{}", // yes this is valid. yes I’m just upset as you are :(
+			want:   ":hover.a.astro-XXXXXX:focus{}",
+		},
+		{
+			name:   "more weird chaining",
+			source: ":not(.is-disabled).a{}",
+			want:   ":not(.is-disabled).a.astro-XXXXXX{}",
+		},
+		{
+			name:   "body",
+			source: "body h1{}",
+			want:   "body h1.astro-XXXXXX{}",
+		},
+		{
+			name:   "body class",
+			source: "body.theme-dark{}",
+			want:   "body.theme-dark{}",
+		},
+		{
+			name:   "html and body",
+			source: "html,body{}",
+			want:   "html,body{}",
+		},
+		{
+			name:   "escaped characters",
+			source: ".class\\:class:focus{}",
+			want:   ".class\\:class.astro-XXXXXX:focus{}",
+		},
+		// the following tests assert we leave valid CSS alone
+		{
+			name:   "keyframes",
+			source: "@keyframes shuffle{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",
+			want:   "@keyframes shuffle{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",
+		},
+		{
+			name:   "keyframes 2",
+			source: "@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}",
+			want:   "@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}",
+		},
+		{
+			name:   "charset",
+			source: "@charset \"utf-8\";",
+			want:   "@charset \"utf-8\";",
+		},
+		{
+			name:   "import (plain)",
+			source: "@import \"./my-file.css\";",
+			want:   "@import \"./my-file.css\";",
+		},
+		{
+			name:   "import (url)",
+			source: "@import url(\"./my-file.css\");",
+			want:   "@import url(\"./my-file.css\");",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// note: the "{}" is only added to make it valid CSS
+			code := test_utils.Dedent("<style>\n" + tt.source + " \n</style>")
+			doc, err := tycho.Parse(strings.NewReader(code))
+			if err != nil {
+				t.Error(err)
+			}
+			styleEl := doc.LastChild.FirstChild.FirstChild // note: root is <html>, and we need to get <style> which lives in head
+			styles := []*tycho.Node{styleEl}
+			ScopeStyle(styles, TransformOptions{Scope: "XXXXXX"})
+			got := styles[0].FirstChild.Data
+			if tt.want != got {
+				t.Error(fmt.Sprintf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Porting this test into the Go compiler: https://github.com/snowpackjs/astro/blob/main/packages/astro/test/astro-scoped-styles.test.js.

This adds support for `:global()` as well as some trickier CSS queries that can easily be messed up.

✅ All tests added are passing (`scope-css_test.go`), but it should be noted that the `main` branch isn’t passing yet so CI will still fail overall.

![Screen Shot 2021-09-02 at 19 29 01](https://user-images.githubusercontent.com/1369770/131936899-f79d8f61-2679-489f-92b6-6a82d19f6ec6.png)
