### PR TITLE
Do not insert `CommentNode` into slots

### DIFF
--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -504,7 +504,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 							}
 						}
 					}
-					if c.Type != TextNode || (c.Type == TextNode && strings.TrimSpace(c.Data) != "") {
+					// Only slot ElementNodes or non-empty TextNodes!
+					// CommentNode and others should not be slotted
+					if c.Type == ElementNode || (c.Type == TextNode && strings.TrimSpace(c.Data) != "") {
 						slottedChildren[slotName] = append(slottedChildren[slotName], c)
 					}
 				}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -156,6 +156,39 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			},
 		},
 		{
+			name: "slots (basic)",
+			source: `---
+import Component from 'test';
+---
+<Component>
+	<div>Default</div>
+	<div slot="named">Named</div>
+</Component>`,
+			want: want{
+				imports:     "",
+				frontmatter: []string{`import Component from 'test';`},
+				styles:      []string{},
+				code:        `${$$renderComponent($$result,'Component',Component, {},{"default": () => $$render` + "`" + `<div>Default</div>` + "`" + `,"named": () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
+			},
+		},
+		{
+			name: "slots (no comments)",
+			source: `---
+import Component from 'test';
+---
+<Component>
+	<div>Default</div>
+	<!-- A comment! -->
+	<div slot="named">Named</div>
+</Component>`,
+			want: want{
+				imports:     "",
+				frontmatter: []string{`import Component from 'test';`},
+				styles:      []string{},
+				code:        `${$$renderComponent($$result,'Component',Component, {},{"default": () => $$render` + "`" + `<div>Default</div>` + "`" + `,"named": () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
+			},
+		},
+		{
 			name: "head expression",
 			source: `---
 const name = "world";


### PR DESCRIPTION
Previously `<Component><!-- comment --></Component>` would not render a fallback because `<!-- comment -->` was passed in as a slotted node.

We lose a little fidelity here, but I can't think of a good way to preserve comments when passing them to various `<slot>` elements.