### PR TITLE
Fix dynamic classes

### DIFF
--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -1,6 +1,8 @@
 package transform
 
 import (
+	"strings"
+
 	tycho "github.com/snowpackjs/astro/internal"
 )
 
@@ -33,10 +35,32 @@ var NeverScopedElements map[string]bool = map[string]bool{
 func injectScopedClass(n *tycho.Node, opts TransformOptions) {
 	for i, attr := range n.Attr {
 		// If we find an existing class attribute, append the scoped class
-		if attr.Key == "class" {
-			attr.Val = attr.Val + " astro-" + opts.Scope
-			n.Attr[i] = attr
-			return
+		if attr.Key == "class" || (n.Component && attr.Key == "className") {
+			switch attr.Type {
+			case tycho.ShorthandAttribute:
+				if n.Component {
+					attr.Val = attr.Key + ` + " astro-` + opts.Scope + `"`
+					attr.Type = tycho.ExpressionAttribute
+					n.Attr[i] = attr
+					return
+				}
+			case tycho.EmptyAttribute:
+				// instead of an empty string
+				attr.Type = tycho.QuotedAttribute
+				attr.Val = "astro-" + opts.Scope
+				n.Attr[i] = attr
+				return
+			case tycho.QuotedAttribute, tycho.TemplateLiteralAttribute:
+				// as a plain string
+				attr.Val = strings.TrimSpace(attr.Val) + " astro-" + opts.Scope
+				n.Attr[i] = attr
+				return
+			case tycho.ExpressionAttribute:
+				// as an expression
+				attr.Val = attr.Val + ` + " astro-` + opts.Scope + `"`
+				n.Attr[i] = attr
+				return
+			}
 		}
 	}
 	// If we didn't find an existing class attribute, let's add one

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -1,8 +1,6 @@
 package transform
 
 import (
-	"strings"
-
 	tycho "github.com/snowpackjs/astro/internal"
 )
 
@@ -52,7 +50,7 @@ func injectScopedClass(n *tycho.Node, opts TransformOptions) {
 				return
 			case tycho.QuotedAttribute, tycho.TemplateLiteralAttribute:
 				// as a plain string
-				attr.Val = strings.TrimSpace(attr.Val) + " astro-" + opts.Scope
+				attr.Val = attr.Val + " astro-" + opts.Scope
 				n.Attr[i] = attr
 				return
 			case tycho.ExpressionAttribute:

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -49,8 +49,6 @@ func printToSource(buf bytes.Buffer, node *tycho.Node) string {
 }
 
 func TestScopeHTML(t *testing.T) {
-	// note: the tests have hashes inlined because it’s easier to read
-	// note: this must be valid CSS, hence the empty "{}"
 	tests := []struct {
 		name   string
 		source string

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -65,9 +65,9 @@ func TestScopeHTML(t *testing.T) {
 			want:   `<div class="test astro-XXXXXX"></div>`,
 		},
 		{
-			name:   "quoted trim",
+			name:   "quoted no trim",
 			source: `<div class="test " />`,
-			want:   `<div class="test astro-XXXXXX"></div>`,
+			want:   `<div class="test  astro-XXXXXX"></div>`,
 		},
 		{
 			name:   "expression string",

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -1,0 +1,123 @@
+package transform
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	astro "github.com/snowpackjs/astro/internal"
+	tycho "github.com/snowpackjs/astro/internal"
+	"golang.org/x/net/html/atom"
+)
+
+func printToSource(buf bytes.Buffer, node *tycho.Node) string {
+	if node.Type == tycho.ElementNode {
+		buf.WriteString(fmt.Sprintf(`<%s`, node.Data))
+		for _, attr := range node.Attr {
+			if attr.Namespace != "" {
+				buf.WriteString(attr.Namespace)
+				buf.WriteString(":")
+			}
+
+			buf.WriteString(" ")
+			switch attr.Type {
+			case astro.QuotedAttribute:
+				buf.WriteString(attr.Key)
+				buf.WriteString("=")
+				buf.WriteString(`"` + attr.Val + `"`)
+			case astro.EmptyAttribute:
+				buf.WriteString(attr.Key)
+			case astro.ExpressionAttribute:
+				buf.WriteString(attr.Key)
+				buf.WriteString("=")
+				buf.WriteString(`{` + strings.TrimSpace(attr.Val) + `}`)
+			case astro.SpreadAttribute:
+				buf.WriteString(`{...` + strings.TrimSpace(attr.Val) + `}`)
+			case astro.ShorthandAttribute:
+				buf.WriteString(attr.Key)
+				buf.WriteString("=")
+				buf.WriteString(`{` + strings.TrimSpace(attr.Key) + `}`)
+			case astro.TemplateLiteralAttribute:
+				buf.WriteString(attr.Key)
+				buf.WriteString("=`" + strings.TrimSpace(attr.Val) + "`")
+			}
+		}
+		buf.WriteString(fmt.Sprintf(`></%s>`, node.Data))
+	}
+	return buf.String()
+}
+
+func TestScopeHTML(t *testing.T) {
+	// note: the tests have hashes inlined because it’s easier to read
+	// note: this must be valid CSS, hence the empty "{}"
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "none",
+			source: "<div />",
+			want:   `<div class="astro-XXXXXX"></div>`,
+		},
+		{
+			name:   "quoted",
+			source: `<div class="test" />`,
+			want:   `<div class="test astro-XXXXXX"></div>`,
+		},
+		{
+			name:   "quoted trim",
+			source: `<div class="test " />`,
+			want:   `<div class="test astro-XXXXXX"></div>`,
+		},
+		{
+			name:   "expression string",
+			source: `<div class={"test"} />`,
+			want:   `<div class={"test" + " astro-XXXXXX"}></div>`,
+		},
+		{
+			name:   "expression function",
+			source: `<div class={clsx({ [test]: true })} />`,
+			want:   `<div class={clsx({ [test]: true }) + " astro-XXXXXX"}></div>`,
+		},
+		{
+			name:   "empty",
+			source: "<div class />",
+			want:   `<div class="astro-XXXXXX"></div>`,
+		},
+		{
+			name:   "template literal",
+			source: "<div class=`${value}` />",
+			want:   "<div class=`${value} astro-XXXXXX`></div>",
+		},
+		{
+			name:   "component className",
+			source: `<Component className="test" />`,
+			want:   `<Component className="test astro-XXXXXX"></Component>`,
+		},
+		{
+			name:   "component className expression",
+			source: `<Component className={"test"} />`,
+			want:   `<Component className={"test" + " astro-XXXXXX"}></Component>`,
+		},
+		{
+			name:   "component className shorthand",
+			source: "<Component {className} />",
+			want:   `<Component className={className + " astro-XXXXXX"}></Component>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := tycho.ParseFragment(strings.NewReader(tt.source), &tycho.Node{Type: astro.ElementNode, DataAtom: atom.Body, Data: atom.Body.String()})
+			if err != nil {
+				t.Error(err)
+			}
+			ScopeElement(nodes[0], TransformOptions{Scope: "XXXXXX"})
+			got := printToSource(*bytes.NewBuffer([]byte{}), nodes[0])
+			if tt.want != got {
+				t.Error(fmt.Sprintf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes https://github.com/snowpackjs/astro-repl/issues/10 and a few other edge cases. Handles as many scoped class attribute situations as possible.

Unhandled, and unclear _how_ to handle: `{...value}` that contains `class`.