### PR TITLE
Fix text following expression

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1609,9 +1609,7 @@ func textIM(p *parser) bool {
 	case EndExpressionToken:
 		p.addLoc()
 		p.oe.pop()
-		p.im = p.originalIM
-		p.originalIM = nil
-		return p.tok.Type == EndExpressionToken
+		return true
 	}
 	p.im = p.originalIM
 	p.originalIM = nil

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -407,6 +407,16 @@ import Widget2 from '../components/Widget2.astro';`},
   </head><body></body></html>`,
 			},
 		},
+		{
+			name:   "text after title expression",
+			source: `<title>a {expr} b</title>`,
+			want: want{
+				imports:     "",
+				frontmatter: []string{},
+				styles:      []string{},
+				code:        `<html><head><title>a ${expr} b</title></head><body></body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -417,6 +417,16 @@ import Widget2 from '../components/Widget2.astro';`},
 				code:        `<html><head><title>a ${expr} b</title></head><body></body></html>`,
 			},
 		},
+		{
+			name:   "text after title expressions",
+			source: `<title>a {expr} b {expr} c</title>`,
+			want: want{
+				imports:     "",
+				frontmatter: []string{},
+				styles:      []string{},
+				code:        `<html><head><title>a ${expr} b ${expr} c</title></head><body></body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -280,6 +280,11 @@ func TestExpressions(t *testing.T) {
 			"{false ? <div>#f</div> : <div>#t</div>}",
 			[]TokenType{StartExpressionToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, StartTagToken, TextToken, EndTagToken, EndExpressionToken},
 		},
+		{
+			"title",
+			"<title>test {expr} test</title>",
+			[]TokenType{StartTagToken, TextToken, StartExpressionToken, TextToken, EndExpressionToken, TextToken, EndTagToken},
+		},
 	}
 
 	runTokenTypeTest(t, Expressions)


### PR DESCRIPTION
Previously, an `EndExpressionToken` in the `textIM` would revert the parser to its' original InsertionMode. Turns out, that's the wrong thing to do! If we're in `textIM`, anything after the expression should remain in the `textIM`. The InsertionMode will be reset automatically.

Closes https://github.com/snowpackjs/astro/issues/1362