### PR TITLE
Sort slot keys for stable output

### DIFF
--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	. "github.com/snowpackjs/astro/internal"
@@ -416,7 +417,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					p.print(`"` + a.Val + `"`)
 					slotted = true
 				default:
-					panic("slot[name] must does must be a static string")
+					panic("slot[name] must be a static string")
 				}
 				// if i != len(n.Attr)-1 {
 				// 	p.print("")
@@ -509,7 +510,14 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						slottedChildren[slotName] = append(slottedChildren[slotName], c)
 					}
 				}
-				for slotName, children := range slottedChildren {
+				// fix: sort keys for stable output
+				slottedKeys := make([]string, 0, len(slottedChildren))
+				for k := range slottedChildren {
+					slottedKeys = append(slottedKeys, k)
+				}
+				sort.Strings(slottedKeys)
+				for _, slotName := range slottedKeys {
+					children := slottedChildren[slotName]
 					p.print(fmt.Sprintf(`"%s": () => `, slotName))
 					p.printTemplateLiteralOpen()
 					for _, child := range children {


### PR DESCRIPTION
Our `slot` tests were flaky because they relied on unstable output. This fixes the `slot` output so that it is always alphabetical.

This shouldn't have an effect on userland code because slots are explicitly placed by the user. They never access this object directly. This just fixes our test suite.