### PR TITLE
Allow top-level conditional expressions

### DIFF
--- a/.changeset/brown-windows-fold.md
+++ b/.changeset/brown-windows-fold.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix for using conditionals at the top-level

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -732,11 +732,10 @@ func beforeHeadIM(p *parser) bool {
 		// Ignore the token.
 		return true
 	case StartExpressionToken:
+		p.parseImpliedToken(StartTagToken, a.Head, a.Head.String())
 		p.addExpression()
-		return true
-	case EndExpressionToken:
-		p.addLoc()
-		p.oe.pop()
+		p.setOriginalIM()
+		p.im = expressionIM
 		return true
 	}
 	p.parseImpliedToken(StartTagToken, a.Head, a.Head.String())
@@ -2356,6 +2355,28 @@ func afterAfterFramesetIM(p *parser) bool {
 		// Ignore the token.
 	}
 	return true
+}
+
+func expressionIM(p *parser) bool {
+	switch p.tok.Type {
+	case ErrorToken:
+		p.oe.pop()
+	case TextToken:
+		return textIM(p)
+	case StartTagToken:
+		return inBodyIM(p)
+	case EndTagToken:
+		return inBodyIM(p)
+	case EndExpressionToken:
+		p.addLoc()
+		p.oe.pop()
+		p.im = p.originalIM
+		p.originalIM = nil
+		return true
+	}
+	p.im = p.originalIM
+	p.originalIM = nil
+	return p.tok.Type == EndTagToken
 }
 
 func ignoreTheRemainingTokens(p *parser) bool {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -45,7 +45,6 @@ type testcase struct {
 	name   string
 	source string
 	only   bool
-	frag   bool
 	want   want
 }
 


### PR DESCRIPTION
This fixes https://github.com/snowpackjs/astro/issues/1493

You can do stuff like:

```astro
{cond && <span></span>}
```

At the top-level now.