### PR TITLE
Fix JS Scanner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/norunners/vert v0.0.0-20210320050952-39b24b3cdf94
 	github.com/tdewolff/parse v2.3.4+incompatible
-	github.com/tdewolff/test v1.0.6 // indirect
+	github.com/tdewolff/parse/v2 v2.5.22
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/natemoo-re/vert v0.0.0-natemoo-re.7 h1:nhfKslS16o2Uruqt8Bwv8ZFYUuf+PW
 github.com/natemoo-re/vert v0.0.0-natemoo-re.7/go.mod h1:67MuD9cDWe6pmhyQrElFlSNMMzL0CMUdFURKxJSvxUM=
 github.com/tdewolff/parse v2.3.4+incompatible h1:x05/cnGwIMf4ceLuDMBOdQ1qGniMoxpP46ghf0Qzh38=
 github.com/tdewolff/parse v2.3.4+incompatible/go.mod h1:8oBwCsVmUkgHO8M5iCzSIDtpzXOT0WXX9cWhz+bIzJQ=
+github.com/tdewolff/parse/v2 v2.5.22 h1:KXMHTyx4VTL6Zu9a94SULQalDMvtP5FQq10mnSfaoGs=
+github.com/tdewolff/parse/v2 v2.5.22/go.mod h1:WzaJpRSbwq++EIQHYIRTpbYKNA3gn9it1Ik++q4zyho=
 github.com/tdewolff/test v1.0.6 h1:76mzYJQ83Op284kMT+63iCNCI7NEERsIN8dLM+RiKr4=
 github.com/tdewolff/test v1.0.6/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff h1:j2EK/QoxYNBsXI4R7fQkkRUk8y6wnOBI+6hgPdP/6Ds=

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -1,259 +1,118 @@
 package js_scanner
 
-// An ImportType is the type of import.
-type ImportType uint32
+import (
+	"io"
 
-const (
-	StandardImport ImportType = iota
-	DynamicImport
+	"github.com/tdewolff/parse/v2"
+	"github.com/tdewolff/parse/v2/js"
 )
 
-type ImportStatement struct {
-	Type           ImportType
-	Start          int
-	End            int
-	StatementStart int
-	StatementEnd   int
-}
+// This function returns the index at which we should split the frontmatter.
+// The first slice contains any top-level imports/exports, which are global.
+// The second slice contains any non-exported declarations, which are scoped to the render body
+//
+// Why use a lexical scan here?
+//   1. We can stop lexing as soon as we hit a non-exported token
+//   2. Lexing supports malformed modules, they'll throw at runtime instead of compilation
+//   3. `tdewolff/parse/v2` doesn't support TypeScript parsing yet, but we can lex it fine
+func FindRenderBody(source []byte) int {
+	l := js.NewLexer(parse.NewInputBytes(source))
+	i := 0
+	pairs := make(map[byte]int, 0)
 
-var source []byte
-var pos int
+	// Let's lex the script until we find what we need!
+	for {
+		token, value := l.Next()
+		openPairs := pairs['{'] > 0 || pairs['('] > 0 || pairs['['] > 0
 
-// TODO: ignore `await` inside of function bodies
-func FindRenderBody(_source []byte) int {
-	source = _source
-	pos = 0
-	lastBr := 0
-	for ; pos < len(source)-1; pos++ {
-		c := readCommentWhitespace(false)
-		switch true {
-		case isBr(c) || c == ';':
-			// Track the last position of a linebreak of ;
-			// This is a rough proxy for "end of previous statement"
-			lastBr = pos
-		case c == 'A':
-			// If we access the Astro global, we're in the function body
-			if isKeywordStart() && str_eq5('A', 's', 't', 'r', 'o') {
-				return lastBr + 1
+		if token == js.ErrorToken {
+			if l.Err() != io.EOF {
+				return -1
 			}
-		case c == 'a':
-			// If we have to await something, we're in the function body
-			if isKeywordStart() && str_eq5('a', 'w', 'a', 'i', 't') {
-				return lastBr + 1
-			}
-		case c == '/':
-			if str_eq2('/', '/') {
-				readLineComment()
-				continue
-			} else if str_eq2('/', '*') {
-				readBlockComment(true)
-				continue
-			}
+			break
 		}
-	}
-	return -1
-}
 
-func HasExports(_source []byte) bool {
-	source = _source
-	pos = 0
-	for ; pos < len(source)-1; pos++ {
-		c := readCommentWhitespace(true)
-		switch true {
-		case c == 'e':
-			if isKeywordStart() && str_eq6('e', 'x', 'p', 'o', 'r', 't') {
-				return true
-			}
-		case c == '/':
-			if str_eq2('/', '/') {
-				readLineComment()
-				continue
-			} else if str_eq2('/', '*') {
-				readBlockComment(true)
-				continue
-			}
-		}
-	}
-	return false
-}
-
-func NextImportSpecifier(_source []byte, _pos int) (int, string) {
-	source = _source
-	pos = _pos
-	inImport := false
-	var cont bool
-	var start int
-	end := 0
-
-MainLoop:
-	for ; pos < len(source)-1; pos++ {
-		c := readCommentWhitespace(true)
-
-		if inImport {
-			if c == '"' || c == '\'' {
-				pos++
-				start = pos
-				readString(start, c)
-				end = pos
-
-				// Continue the loop
-				cont = true
-				break MainLoop
-			}
-		} else {
-			switch true {
-			case c == 'i':
-				if isKeywordStart() && str_eq6('i', 'm', 'p', 'o', 'r', 't') {
-					pos += 6
-					inImport = true
-					continue
-				}
-			case c == '/':
-				if str_eq2('/', '/') {
-					readLineComment()
-					continue
-				} else if str_eq2('/', '*') {
-					readBlockComment(true)
-					continue
-				}
-			}
-		}
-	}
-
-	if cont {
-		specifier := source[start:end]
-		return pos, string(specifier)
-	} else {
-		return -1, ""
-	}
-}
-
-// TODO: check for access to $$vars
-func AccessesPrivateVars(_source []byte) bool {
-	source = _source
-	pos = 0
-	for ; pos < len(source)-1; pos++ {
-		c := readCommentWhitespace(true)
-		switch true {
-		// case c == '$':
-		// 	fmt.Println(str_eq2('$', '$'))
-		// 	if isKeywordStart() && str_eq2('$', '$') {
-		// 		return true
-		// 	}
-		case c == '/':
-			if str_eq2('/', '/') {
-				readLineComment()
-				continue
-			} else if str_eq2('/', '*') {
-				readBlockComment(true)
-				continue
-			}
-		}
-	}
-	return false
-}
-
-// Note: non-asii BR and whitespace checks omitted for perf / footprint
-// if there is a significant user need this can be reconsidered
-func isBr(c byte) bool {
-	return c == '\r' || c == '\n'
-}
-
-func isWsNotBr(c byte) bool {
-	return c == 9 || c == 11 || c == 12 || c == 32 || c == 160
-}
-
-func isBrOrWs(c byte) bool {
-	return c > 8 && c < 14 || c == 32 || c == 160
-}
-
-func isBrOrWsOrPunctuatorNotDot(c byte) bool {
-	return c > 8 && c < 14 || c == 32 || c == 160 || isPunctuator(c) && c != '.'
-}
-
-func isPunctuator(ch byte) bool {
-	// 23 possible punctuator endings: !%&()*+,-./:;<=>?[]^{}|~
-	return ch == '!' || ch == '%' || ch == '&' ||
-		ch > 39 && ch < 48 || ch > 57 && ch < 64 ||
-		ch == '[' || ch == ']' || ch == '^' ||
-		ch > 122 && ch < 127
-}
-
-func str_eq2(c1 byte, c2 byte) bool {
-	return len(source[pos:]) >= 2 && source[pos+1] == c2 && source[pos] == c1
-}
-
-func str_eq5(c1 byte, c2 byte, c3 byte, c4 byte, c5 byte) bool {
-	return len(source[pos:]) >= 5 && source[pos+4] == c5 && source[pos+3] == c4 && source[pos+2] == c3 && source[pos+1] == c2 && source[pos] == c1
-}
-
-func str_eq6(c1 byte, c2 byte, c3 byte, c4 byte, c5 byte, c6 byte) bool {
-	return len(source[pos:]) >= 6 && source[pos+5] == c6 && source[pos+4] == c5 && source[pos+3] == c4 && source[pos+2] == c3 && source[pos+1] == c2 && source[pos] == c1
-}
-
-func isKeywordStart() bool {
-	return isBrOrWsOrPunctuatorNotDot(source[pos-1])
-}
-
-func readBlockComment(br bool) {
-	pos++
-	for ; pos < len(source)-1; pos++ {
-		c := source[pos]
-		if !br && isBr(c) {
-			return
-		}
-		if c == '*' && source[pos+1] == '/' {
-			pos++
-			return
-		}
-	}
-}
-
-func readLineComment() {
-	for ; pos < len(source)-1; pos++ {
-		c := source[pos]
-		if c == '\n' || c == '\r' {
-			return
-		}
-	}
-}
-
-func readCommentWhitespace(br bool) byte {
-	var c byte
-	for ; pos < len(source)-1; pos++ {
-		c = source[pos]
-		switch true {
-		case c == '/':
-			if str_eq2('/', '/') {
-				readLineComment()
-				continue
-			} else if str_eq2('/', '*') {
-				readBlockComment(true)
-				continue
-			} else {
-				return c
-			}
-		case (br && !isBrOrWs(c)):
-			return c
-		case (!br && !isWsNotBr(c)):
-			return c
-		}
-	}
-	return c
-}
-
-func readString(start int, quoteChar byte) {
-	var c byte
-
-MainLoop:
-	for ; pos < len(source)-1; pos++ {
-		c = source[pos]
-		switch true {
-		case c == '\\':
-			pos++
+		// Common delimeters. Track their length, then skip.
+		if token == js.WhitespaceToken || token == js.LineTerminatorToken || token == js.SemicolonToken {
+			i += len(value)
 			continue
-		case c == quoteChar:
-			break MainLoop
 		}
+
+		// Imports should be consumed up until we find a specifier,
+		// then we can exit after the following line terminator or semicolon
+		if token == js.ImportToken {
+			i += len(value)
+			foundSpecifier := false
+			for {
+				next, nextValue := l.Next()
+				i += len(nextValue)
+				if next == js.StringToken {
+					foundSpecifier = true
+				}
+				if foundSpecifier && (next == js.LineTerminatorToken || next == js.SemicolonToken) {
+					break
+				}
+			}
+			continue
+		}
+
+		// Exports should be consumed until all opening braces are closed,
+		// a specifier is found, and a line terminator has been found
+		if token == js.ExportToken {
+			foundIdentifier := false
+			foundSemicolonOrLineTerminator := false
+			i += len(value)
+			for {
+				next, nextValue := l.Next()
+				i += len(nextValue)
+				if js.IsIdentifier(next) {
+					foundIdentifier = true
+				} else if next == js.LineTerminatorToken || next == js.SemicolonToken {
+					foundSemicolonOrLineTerminator = true
+				} else if js.IsPunctuator(next) {
+					if nextValue[0] == '{' || nextValue[0] == '(' || nextValue[0] == '[' {
+						pairs[nextValue[0]]++
+					} else if nextValue[0] == '}' {
+						pairs['{']--
+					} else if nextValue[0] == ')' {
+						pairs['(']--
+					} else if nextValue[0] == ']' {
+						pairs['[']--
+					}
+				}
+
+				if foundIdentifier && foundSemicolonOrLineTerminator && pairs['{'] == 0 && pairs['('] == 0 && pairs['['] == 0 {
+					break
+				}
+			}
+			continue
+		}
+
+		// Track opening and closing braces
+		if js.IsPunctuator(token) {
+			if value[0] == '{' || value[0] == '(' || value[0] == '[' {
+				pairs[value[0]]++
+				i += len(value)
+				continue
+			} else if value[0] == '}' {
+				pairs['{']--
+			} else if value[0] == ')' {
+				pairs['(']--
+			} else if value[0] == ']' {
+				pairs['[']--
+			}
+		}
+
+		// If there are no open pairs and we hit a reserved word (var/let/const/async/function)
+		// return our index! This is the first non-exported declaration
+		if !openPairs && js.IsReservedWord(token) {
+			return i
+		}
+
+		// Track our current position
+		i += len(value)
 	}
+
+	// If we haven't found anything... there's nothing to find! Split at the start.
+	return 0
 }

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -1,0 +1,117 @@
+package js_scanner
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFindRenderBody(t *testing.T) {
+	// note: the tests have hashes inlined because it’s easier to read
+	// note: this must be valid CSS, hence the empty "{}"
+	tests := []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{
+			name:   "basic",
+			source: `const value = "test"`,
+			want:   0,
+		},
+		{
+			name: "import",
+			source: `import { fn } from "package";
+const b = await fetch();`,
+			want: 30,
+		},
+		{
+			name: "big import",
+			source: `import {
+	a,
+	b, 
+	c,
+	d,
+} from "package"
+
+const b = await fetch();`,
+			want: 44,
+		},
+		{
+			name: "import with comment",
+			source: `// comment
+import { fn } from "package";
+const b = await fetch();`,
+			want: 41,
+		},
+		{
+			name: "import assertion",
+			source: `// comment
+import { fn } from "package" assert { it: 'works' };
+const b = await fetch();`,
+			want: 64,
+		},
+		{
+			name: "import assertion",
+			source: `// comment
+import { 
+	fn
+} from 
+	"package" 
+	assert { 
+		it: 'works'
+	};
+const b = await fetch();`,
+			want: 74,
+		},
+		{
+			name: "import/export",
+			source: `import { fn } from "package";
+export async fn() {}
+const b = await fetch()`,
+			want: 51,
+		},
+		{
+			name: "getStaticPaths",
+			source: `import { fn } from "package";
+export async function getStaticPaths() {
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: 121,
+		},
+		{
+			name: "getStaticPaths with comments",
+			source: `import { fn } from "package";
+export async function getStaticPaths() {
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: 121,
+		},
+		{
+			name: "getStaticPaths with semicolon",
+			source: `import { fn } from "package";
+export async function getStaticPaths() {
+	const content = Astro.fetchContent('**/*.md');
+}; const b = await fetch()`,
+			want: 122,
+		},
+		{
+			name: "multiple imports",
+			source: `import { a } from "a";
+import { b } from "b";
+import { c } from "c";
+const d = await fetch()`,
+			want: 69,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindRenderBody([]byte(tt.source))
+			if tt.want != got {
+				t.Error(fmt.Sprintf("\nFAIL: %s\n  want: %v\n  got:  %v", tt.name, tt.want, got))
+				fmt.Println(tt.source[got:])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow up to #50, which was closed because it was error-prone.

This new approach is much more straight-forward: split the frontmatter as soon as we encounter a non-exported declaration.

It is powered by a lexical scan that does as little work as possible, using a JS tokenizing library rather than handrolled utils. 

Test coverage is also vastly improved!