### PR TITLE
Fix JS comments in expressions

### DIFF
--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -262,20 +262,18 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			p.addSourceMapping(c.Loc[0])
 			if c.Type == TextNode {
 				p.print(c.Data)
-			} else {
-				if c.PrevSibling == nil || (c.PrevSibling != nil && c.PrevSibling.Type == TextNode) {
-					// TODO: where is this used?
-					// c.NextSibling.Type != TextNode
-					p.printTemplateLiteralOpen()
-				}
-				render1(p, c, RenderOptions{
-					isRoot:       false,
-					isExpression: true,
-					depth:        depth + 1,
-				})
-				if c.NextSibling == nil || (c.NextSibling != nil && c.NextSibling.Type == TextNode) {
-					p.printTemplateLiteralClose()
-				}
+				continue
+			}
+			if c.PrevSibling == nil || c.PrevSibling.Type == TextNode {
+				p.printTemplateLiteralOpen()
+			}
+			render1(p, c, RenderOptions{
+				isRoot:       false,
+				isExpression: true,
+				depth:        depth + 1,
+			})
+			if c.NextSibling == nil || c.NextSibling.Type == TextNode {
+				p.printTemplateLiteralClose()
 			}
 		}
 		p.addSourceMapping(n.Loc[1])

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -172,6 +172,35 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			},
 		},
 		{
+			name: "expressions with JS comments",
+			source: `---
+const items = ['red', 'yellow', 'blue'];
+---
+<div>
+  {items.map((item) => (
+    // foo < > < }
+    <div id={color}>color</div>
+  ))}
+  {items.map((item) => (
+    /* foo < > < } */ <div id={color}>color</div>
+  ))}
+</div>`,
+			want: want{
+				imports:     "",
+				frontmatter: []string{"const items = ['red', 'yellow', 'blue'];"},
+				styles:      []string{},
+				code: `<html><head></head><body><div>
+  ${items.map((item) => (
+    // foo < > < }
+$$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
+  ))}
+  ${items.map((item) => (
+    /* foo < > < } */$$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
+  ))}
+</div></body></html>`,
+			},
+		},
+		{
 			name: "slots (basic)",
 			source: `---
 import Component from 'test';

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -180,6 +180,24 @@ func TestFrontmatter(t *testing.T) {
 			`,
 			[]TokenType{FrontmatterFenceToken, TextToken, FrontmatterFenceToken},
 		},
+		{
+			"single-line comments",
+			`
+			---
+			// --- <div>
+			---
+			`,
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, FrontmatterFenceToken},
+		},
+		{
+			"multi-line comments",
+			`
+			---
+			/* --- <div> */
+			---
+			`,
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, FrontmatterFenceToken},
+		},
 		// {
 		// 	"less than with no space isn’t a tag",
 		// 	`
@@ -251,6 +269,16 @@ func TestExpressions(t *testing.T) {
 			[]TokenType{StartExpressionToken, TextToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, EndExpressionToken},
 		},
 		{
+			"expression map",
+			`<div>
+			  {items.map((item) => (
+          // < > < }
+          <div>{item}</div>
+        ))}
+      </div>`,
+			[]TokenType{StartTagToken, TextToken, StartExpressionToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, TextToken, EndTagToken},
+		},
+		{
 			"left bracket within string",
 			`{"{"}`,
 			[]TokenType{StartExpressionToken, TextToken, EndExpressionToken},
@@ -264,6 +292,18 @@ func TestExpressions(t *testing.T) {
 			"expression within string",
 			`{'{() => <Component />}'}`,
 			[]TokenType{StartExpressionToken, TextToken, EndExpressionToken},
+		},
+		{
+			"expression within single-line comment",
+			`{ // < > < }
+		    'text'
+		  }`,
+			[]TokenType{StartExpressionToken, TextToken, TextToken, TextToken, EndExpressionToken},
+		},
+		{
+			"expression within multi-line comment",
+			`{/* < > < } */ 'text'}`,
+			[]TokenType{StartExpressionToken, TextToken, TextToken, EndExpressionToken},
 		},
 		{
 			"expression with nested strings",


### PR DESCRIPTION
Fixes a tokenizer bug where a `}` inside a JS comment would be counted as the end of an expression. We were checking for strings, but weren’t checking for comments.

Adds tests to ensure it’s working properly