### PR TITLE
Fix expression parsing when HTML is wrapped in parens

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -815,7 +815,7 @@ func inHeadIM(p *parser) bool {
 		switch p.tok.DataAtom {
 		case a.Head:
 			p.addLoc()
-			p.oe.pop()
+			p.popUntil(defaultScope, a.Head)
 			p.im = afterHeadIM
 			return true
 		case a.Body, a.Html, a.Br:
@@ -1588,7 +1588,7 @@ func (p *parser) inBodyEndTagOther(tagAtom a.Atom, tagName string) {
 func textIM(p *parser) bool {
 	switch p.tok.Type {
 	case ErrorToken:
-		p.oe.pop()
+		break
 	case TextToken:
 		d := p.tok.Data
 		if n := p.oe.top(); n.DataAtom == a.Textarea && n.FirstChild == nil {
@@ -2417,7 +2417,12 @@ func expressionIM(p *parser) bool {
 		if p.isInsideHead() {
 			switch p.tok.DataAtom {
 			case a.Noframes, a.Style, a.Script, a.Title, a.Noscript, a.Base, a.Basefont, a.Bgsound, a.Link, a.Meta:
-				return textIM(p)
+				origIm := p.originalIM
+				p.originalIM = nil
+				ret := inHeadIM(p)
+				p.im = expressionIM
+				p.originalIM = origIm
+				return ret
 			default:
 				for {
 					if n.Expression {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -650,6 +650,21 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
 				code:        `<html><head>${$$renderComponent($$result,'BaseHead',BaseHead,{})}<link href="test"></head><body></body></html>`,
 			},
 		},
+		{
+			name: "Nested HTML in expressions, wrapped in parens",
+			source: `---
+const image = './penguin.png';
+const canonicalURL = new URL('http://example.com');
+---
+{image && (<meta property="og:image" content={new URL(image, canonicalURL)}>)}`,
+			want: want{
+				imports: "",
+				frontmatter: []string{"", `const image = './penguin.png';
+const canonicalURL = new URL('http://example.com');`},
+				styles: []string{},
+				code:   "<html><head>${image && ($$render`<meta property=\"og:image\"${$$addAttribute(new URL(image, canonicalURL), \"content\")}>`)}</head><body></body></html>",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- Fixes this sort of thing: `{image && (<meta property="og:image" content={new URL(image, canonicalURL)}>)}`
- Previously we were parsing head elements using textIM (oops).

## Testing

Test added

## Docs

N/A