### PR TITLE
Handle string interpolation within a title

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -1543,6 +1543,14 @@ raw_with_expression_loop:
 			break raw_with_expression_loop
 		}
 
+		// handle string
+		if c == '\'' || c == '"' || c == '`' {
+			z.readString(c)
+			z.tt = TextToken
+			z.data.End = z.raw.End
+			return z.tt
+		}
+
 		if c == '{' || c == '}' {
 			if x := z.raw.End - len("{"); z.raw.Start < x {
 				z.raw.End = x

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -280,10 +280,10 @@ func TestExpressions(t *testing.T) {
 			"expression map",
 			`<div>
 			  {items.map((item) => (
-          // < > < }
-          <div>{item}</div>
-        ))}
-      </div>`,
+		      // < > < }
+		      <div>{item}</div>
+		    ))}
+		  </div>`,
 			[]TokenType{StartTagToken, TextToken, StartExpressionToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, TextToken, EndTagToken},
 		},
 		{
@@ -332,6 +332,11 @@ func TestExpressions(t *testing.T) {
 			"title",
 			"<title>test {expr} test</title>",
 			[]TokenType{StartTagToken, TextToken, StartExpressionToken, TextToken, EndExpressionToken, TextToken, EndTagToken},
+		},
+		{
+			"String interpolation inside an expression within a title",
+			"<title>{content.title && `${title} 🚀 ${title}`}</title>",
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 	}
 


### PR DESCRIPTION
## Changes

- Within titles we go into this `raw_with_expression_loop` mode which previously didn't handle strings. Now it does.

## Testing

Added

## Docs

N/A