### PR TITLE
fixing parsing for CSS variables in style parsing

### DIFF
--- a/.changeset/chilled-socks-buy.md
+++ b/.changeset/chilled-socks-buy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix CSS variable parsing in the scoped CSS transform

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -205,9 +205,14 @@ outer:
 					out += ","
 				}
 			default:
-				out += string(data)
+				strData := string(data)
+				out += strData
 				for _, val := range p.Values() {
 					strVal := string(val.Data)
+					// handle CSS variables
+					if strings.HasPrefix(strData, "--") {
+						out += ":"
+					}
 					out += strVal
 				}
 				out += ";"

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -174,6 +174,11 @@ func TestScopeStyle(t *testing.T) {
 			want:   "body{background-image:url('/assets/bg.jpg');clip-path:polygon(0% 0%,100% 0%,100% 100%,0% 100%);}",
 		},
 		{
+			name:   "variables",
+			source: "body{--bg:red;background:var(--bg);color:black;}",
+			want:   "body{--bg:red;background:var(--bg);color:black;}",
+		},
+		{
 			name:   "keyframes",
 			source: "@keyframes shuffle{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",
 			want:   "@keyframes shuffle{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",


### PR DESCRIPTION
## Changes

Updates the scoped CSS transform to support CSS variables.  Currently, the colon is lost during the transform and `--bg: red` is output as `--bg red`

## Testing

Added a test to make cover CSS variable parsing

## Docs

bug fix only
