### PR TITLE
Fix: `<Fragment>` and `<>`

### DIFF
--- a/.changeset/brown-mirrors-grin.md
+++ b/.changeset/brown-mirrors-grin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix <Fragment> and <> handling

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -2,10 +2,9 @@ package js_scanner
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/snowpackjs/astro/internal/test_utils"
 )
 
 type testcase struct {
@@ -170,29 +169,9 @@ import { c } from "c";`,
 			split := FindRenderBody([]byte(tt.source))
 			got := tt.source[:split]
 			// compare to expected string, show diff if mismatch
-			if diff := ANSIDiff(got, tt.want); diff != "" {
+			if diff := test_utils.ANSIDiff(got, tt.want); diff != "" {
 				t.Error(fmt.Sprintf("mismatch (-want +got):\n%s", diff))
 			}
 		})
 	}
-}
-
-func ANSIDiff(x, y interface{}, opts ...cmp.Option) string {
-	escapeCode := func(code int) string {
-		return fmt.Sprintf("\x1b[%dm", code)
-	}
-	diff := cmp.Diff(x, y, opts...)
-	if diff == "" {
-		return ""
-	}
-	ss := strings.Split(diff, "\n")
-	for i, s := range ss {
-		switch {
-		case strings.HasPrefix(s, "-"):
-			ss[i] = escapeCode(31) + s + escapeCode(0)
-		case strings.HasPrefix(s, "+"):
-			ss[i] = escapeCode(32) + s + escapeCode(0)
-		}
-	}
-	return strings.Join(ss, "\n")
 }

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -387,7 +387,7 @@ func (p *parser) addExpression() {
 }
 
 func isFragment(data string) bool {
-	return len(data) == 0
+	return len(data) == 0 || data == "Fragment"
 }
 
 func isComponent(data string) bool {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -38,6 +38,7 @@ var CREATE_METADATA = "$$createMetadata"
 var METADATA = "$$metadata"
 var RESULT = "$$result"
 var SLOTS = "$$slots"
+var FRAGMENT = "Fragment"
 var BACKTICK = "`"
 
 func (p *printer) print(text string) {
@@ -53,6 +54,7 @@ func (p *printer) printInternalImports(importSpecifier string) {
 		return
 	}
 	p.print(fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.Join([]string{
+		FRAGMENT,
 		"render as " + TEMPLATE_TAG,
 		"createAstro as " + CREATE_ASTRO,
 		"createComponent as " + CREATE_COMPONENT,

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.Join([]string{
+	FRAGMENT,
 	"render as " + TEMPLATE_TAG,
 	"createAstro as " + CREATE_ASTRO,
 	"createComponent as " + CREATE_COMPONENT,
@@ -917,6 +918,20 @@ import { Container, Col, Row } from 'react-bootstrap';
 import * as $$module1 from 'react-bootstrap';`},
 				metadata: `{ modules: [{ module: $$module1, specifier: 'react-bootstrap' }], hydratedComponents: [], hoisted: [] }`,
 				code:     "${$$renderComponent($$result,'Container',Container,{},{\"default\": () => $$render`${$$renderComponent($$result,'Row',Row,{},{\"default\": () => $$render`${$$renderComponent($$result,'Col',Col,{})}<h1>Hi!</h1>`,})}`,})}\n.",
+			},
+		},
+		{
+			name:   "Fragment",
+			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
+			want: want{
+				code: `<html><head></head><body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body></html>`,
+			},
+		},
+		{
+			name:   "Fragment shorthand",
+			source: `<body><><div>Default</div><div>Named</div></></body>`,
+			want: want{
+				code: `<html><head></head><body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body></html>`,
 			},
 		},
 	}

--- a/internal/test_utils/test_utils.go
+++ b/internal/test_utils/test_utils.go
@@ -1,8 +1,10 @@
 package test_utils
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/lithammer/dedent"
 )
 
@@ -14,4 +16,24 @@ func Dedent(input string) string {
 				" \t\r\n"),                        // remove leading whitespace
 			"\n\n\n", "\n\n"),
 	)
+}
+
+func ANSIDiff(x, y interface{}, opts ...cmp.Option) string {
+	escapeCode := func(code int) string {
+		return fmt.Sprintf("\x1b[%dm", code)
+	}
+	diff := cmp.Diff(x, y, opts...)
+	if diff == "" {
+		return ""
+	}
+	ss := strings.Split(diff, "\n")
+	for i, s := range ss {
+		switch {
+		case strings.HasPrefix(s, "-"):
+			ss[i] = escapeCode(31) + s + escapeCode(0)
+		case strings.HasPrefix(s, "+"):
+			ss[i] = escapeCode(32) + s + escapeCode(0)
+		}
+	}
+	return strings.Join(ss, "\n")
 }

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -160,6 +160,16 @@ func TestBasic(t *testing.T) {
 			`<div>Don't panic</div>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
+		{
+			"fragment",
+			`<>foo</>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
+			"fragment",
+			`<Fragment>foo</Fragment>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
 	}
 
 	runTokenTypeTest(t, Basic)

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -1,6 +1,7 @@
 package astro
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,6 +13,12 @@ type TokenTypeTest struct {
 	name     string
 	input    string
 	expected []TokenType
+}
+
+type TokenPanicTest struct {
+	name    string
+	input   string
+	message string
 }
 
 type AttributeTest struct {
@@ -170,9 +177,27 @@ func TestBasic(t *testing.T) {
 			`<Fragment>foo</Fragment>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
+		// Special Case: this should PANIC! Not sure how to test for a panic
+
 	}
 
 	runTokenTypeTest(t, Basic)
+}
+
+func TestPanics(t *testing.T) {
+	Panics := []TokenPanicTest{
+		{
+			"fragment with attributes",
+			`< slot="named">foo</>`,
+			`Unable to assign attributes when using <> Fragment shorthand syntax!
+
+To fix this, please change
+  < slot="named">
+to use the longhand Fragment syntax:
+  <Fragment slot="named">`,
+		},
+	}
+	runPanicTest(t, Panics)
 }
 
 func TestFrontmatter(t *testing.T) {
@@ -545,6 +570,34 @@ func runTokenTypeTest(t *testing.T, suite []TokenTypeTest) {
 			if !reflect.DeepEqual(tokens, tt.expected) {
 				t.Errorf("Tokens = %v\nExpected = %v", tokens, tt.expected)
 			}
+		})
+	}
+}
+
+func runPanicTest(t *testing.T, suite []TokenPanicTest) {
+	for _, tt := range suite {
+		value := test_utils.Dedent(tt.input)
+		t.Run(tt.name, func(t *testing.T) {
+			tokenizer := NewTokenizer(strings.NewReader(value))
+			defer func() {
+				r := recover()
+
+				if r == nil {
+					t.Errorf("%s did not panic\nExpected %s", tt.name, tt.message)
+				}
+
+				if diff := test_utils.ANSIDiff(test_utils.Dedent(r.(string)), test_utils.Dedent(tt.message)); diff != "" {
+					t.Error(fmt.Sprintf("mismatch (-want +got):\n%s", diff))
+				}
+			}()
+			var next TokenType
+			for {
+				next = tokenizer.Next()
+				if next == ErrorToken {
+					break
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
## Changes

- Fixes `Fragment` and `<>` handling for backwards compat
- Panics when encountering `< attr=...>` and guides users to replace with `<Fragment attr=...>`.

## Testing

Panic tests added to tokenizer test suite, refactored `AnsiDiff` into `test_utils` module

## Docs

N/A, matches Astro Classic™ behavior.