### PR TITLE
Add support for `client:only` directive

### DIFF
--- a/.changeset/strange-ties-rule.md
+++ b/.changeset/strange-ties-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add support for `client:only` directive

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -302,6 +302,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	}
 
 	isComponent := (n.Component || n.CustomElement) && n.Data != "Fragment"
+	isClientOnly := isComponent && transform.HasAttr(n, "client:only")
 	isSlot := n.DataAtom == atom.Slot
 
 	p.addSourceMapping(n.Loc[0])
@@ -319,6 +320,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	} else if !isSlot {
 		if n.CustomElement {
 			p.print(fmt.Sprintf("'%s'", n.Data))
+		} else if isClientOnly {
+			p.print("null")
 		} else {
 			p.print(n.Data)
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -149,6 +149,37 @@ import * as $$module1 from '../components';`,
 			},
 		},
 		{
+			name: "client:only component",
+			source: `---
+import { Component } from '../components';
+---
+<html>
+  <head>
+    <title>Hello world</title>
+  </head>
+  <body>
+    <Component client:only />
+  </body>
+</html>`,
+			want: want{
+				imports: "",
+				frontmatter: []string{
+					`import { Component } from '../components';
+
+import * as $$module1 from '../components';`,
+				},
+				styles:   []string{},
+				metadata: `{ modules: [{ module: $$module1, specifier: '../components' }], hydratedComponents: [], hoisted: [] }`,
+				code: `<html>
+  <head>
+    <title>Hello world</title>
+  </head>
+  <body>
+    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true})}
+  </body></html>`,
+			},
+		},
+		{
 			name:   "conditional render",
 			source: `<body>{false ? <div>#f</div> : <div>#t</div>}</body>`,
 			want: want{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -66,7 +66,7 @@ func ExtractScript(doc *tycho.Node, n *tycho.Node) {
 						id = fmt.Sprintf("'%s'", id)
 					}
 
-					if strings.HasPrefix(attr.Key, "client:") {
+					if strings.HasPrefix(attr.Key, "client:") && attr.Key != "client:only" {
 						doc.HydratedComponents = append(doc.HydratedComponents, n)
 						pathAttr := tycho.Attribute{
 							Key:  "client:component-path",


### PR DESCRIPTION
## Changes

- Adds support for `client:only` directive
- Requires updates in `astro/internal`'s `renderComponent` function to gracefully handle this case. PR in progress to `astro`. 
- [] TODO: remove matching import from `metadata`, presumably cannot be SSR'd due to top-level `window` access.
  - Should top-level Component import be removed as well? `esbuild` will treeshake it out automatically.
- [] TODO: determine client import path and client export name ahead of time, since `metadata` won't have that info.

## Testing

Tests added

## Docs

No docs needed
