### PR TITLE
fix: script/style sibling issue

### DIFF
--- a/.changeset/beige-adults-wait.md
+++ b/.changeset/beige-adults-wait.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix issue with `style` and `script` processing where siblings would be skipped

--- a/internal/node.go
+++ b/internal/node.go
@@ -169,6 +169,7 @@ func (n *Node) clone() *Node {
 		Attr:          make([]Attribute, len(n.Attr)),
 		CustomElement: n.CustomElement,
 		Component:     n.Component,
+		Loc:           n.Loc,
 	}
 	copy(m.Attr, n.Attr)
 	return m

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -665,6 +665,7 @@ func beforeHTMLIM(p *parser) bool {
 			p.im = inBodyIM
 			if p.hasSelfClosingToken {
 				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
 			}
 			return true
 		}
@@ -755,6 +756,7 @@ func inHeadIM(p *parser) bool {
 			if p.hasSelfClosingToken {
 				p.addLoc()
 				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
 			}
 			return true
 		}
@@ -783,6 +785,7 @@ func inHeadIM(p *parser) bool {
 			if p.hasSelfClosingToken {
 				p.addLoc()
 				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
 			}
 			return true
 		case a.Noframes, a.Style:
@@ -790,6 +793,7 @@ func inHeadIM(p *parser) bool {
 			if p.hasSelfClosingToken {
 				p.addLoc()
 				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
 			}
 			return true
 		case a.Head:
@@ -826,6 +830,7 @@ func inHeadIM(p *parser) bool {
 			p.addElement()
 			return true
 		}
+
 		switch p.tok.DataAtom {
 		case a.Head:
 			p.addLoc()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -929,13 +929,13 @@ import * as $$module1 from 'react-bootstrap';`},
 </head>
 <div />
 `,
-			want: want{
-				styles: []string{
-					"{props:{\"global\":true},children:`div { color: red }`}",
-					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
-					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:blue;}`}",
-				},
-				code: "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
+		want: want{
+			styles: []string{
+				"{props:{\"global\":true},children:`div { color: red }`}",
+				"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
+				"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:blue;}`}",
+			},
+			code:   "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
 			name:   "Fragment",
 			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -919,6 +919,25 @@ import * as $$module1 from 'react-bootstrap';`},
 				code:     "${$$renderComponent($$result,'Container',Container,{},{\"default\": () => $$render`${$$renderComponent($$result,'Row',Row,{},{\"default\": () => $$render`${$$renderComponent($$result,'Col',Col,{})}<h1>Hi!</h1>`,})}`,})}\n.",
 			},
 		},
+		{
+			name: "Mixed style siblings",
+			source: `
+<head>
+	<style global>div { color: red }</style>
+	<style>div { color: green }</style>
+	<style>div { color: blue }</style>
+</head>
+<div />
+`,
+			want: want{
+				styles: []string{
+					"{props:{\"global\":true},children:`div { color: red }`}",
+					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
+					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:blue;}`}",
+				},
+				code: "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1011,7 +1030,6 @@ func ANSIDiff(x, y interface{}, opts ...cmp.Option) string {
 		case strings.HasPrefix(s, "+"):
 			ss[i] = escapeCode(32) + s + escapeCode(0)
 		}
-		fmt.Println()
 	}
 	return strings.Join(ss, "\n")
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -922,20 +922,23 @@ import * as $$module1 from 'react-bootstrap';`},
 		{
 			name: "Mixed style siblings",
 			source: `
-<head>
-	<style global>div { color: red }</style>
-	<style>div { color: green }</style>
-	<style>div { color: blue }</style>
-</head>
-<div />
-`,
-		want: want{
-			styles: []string{
-				"{props:{\"global\":true},children:`div { color: red }`}",
-				"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
-				"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:blue;}`}",
+				<head>
+					<style global>div { color: red }</style>
+					<style>div { color: green }</style>
+					<style>div { color: blue }</style>
+				</head>
+				<div />
+			`,
+			want: want{
+				styles: []string{
+					"{props:{\"global\":true},children:`div { color: red }`}",
+					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
+					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:blue;}`}",
+				},
+				code: "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
 			},
-			code:   "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
+		},
+		{
 			name:   "Fragment",
 			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -921,14 +921,12 @@ import * as $$module1 from 'react-bootstrap';`},
 		},
 		{
 			name: "Mixed style siblings",
-			source: `
-				<head>
-					<style global>div { color: red }</style>
-					<style>div { color: green }</style>
-					<style>div { color: blue }</style>
-				</head>
-				<div />
-			`,
+			source: `<head>
+	<style global>div { color: red }</style>
+	<style>div { color: green }</style>
+	<style>div { color: blue }</style>
+</head>
+<div />`,
 			want: want{
 				styles: []string{
 					"{props:{\"global\":true},children:`div { color: red }`}",

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -156,6 +156,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken, StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"multiple styles",
+			`<style global>a {}</style><style>b {}</style><style>c {}</style>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken, StartTagToken, TextToken, EndTagToken, StartTagToken, TextToken, EndTagToken},
+		},
+		{
 			"element with single quote",
 			`<div>Don't panic</div>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -23,67 +23,79 @@ func Transform(doc *tycho.Node, opts TransformOptions) *tycho.Node {
 	shouldScope := len(doc.Styles) > 0 && ScopeStyle(doc.Styles, opts)
 	walk(doc, func(n *tycho.Node) {
 		ExtractScript(doc, n)
+		AddComponentProps(doc, n)
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
 	})
+
+	// Important! Remove scripts from original location *after* walking the doc
+	for _, script := range doc.Scripts {
+		script.Parent.RemoveChild(script)
+	}
+
 	return doc
 }
 
 func ExtractStyles(doc *tycho.Node) {
 	walk(doc, func(n *tycho.Node) {
-		if n.Type == tycho.ElementNode {
-			switch n.DataAtom {
-			case a.Style:
-				// Do not extract <style> inside of SVGs
-				if n.Parent != nil && n.Parent.DataAtom == atom.Svg {
-					return
-				}
-				doc.Styles = append(doc.Styles, n)
-				// Remove local style node
-				n.Parent.RemoveChild(n)
+		if n.Type == tycho.ElementNode && n.DataAtom == a.Style {
+			// Do not extract <style> inside of SVGs
+			if n.Parent != nil && n.Parent.DataAtom == atom.Svg {
+				return
 			}
+			doc.Styles = append(doc.Styles, n)
 		}
 	})
+	// Important! Remove styles from original location *after* walking the doc
+	for _, style := range doc.Styles {
+		style.Parent.RemoveChild(style)
+	}
 }
 
+// TODO: cleanup sibling whitespace after removing scripts/styles
+// func removeSiblingWhitespace(n *tycho.Node) {
+// 	if c := n.NextSibling; c != nil && c.Type == tycho.TextNode {
+// 		content := strings.TrimSpace(c.Data)
+// 		if len(content) == 0 {
+// 			c.Parent.RemoveChild(c)
+// 		}
+// 	}
+// }
+
 func ExtractScript(doc *tycho.Node, n *tycho.Node) {
-	if n.Type == tycho.ElementNode {
-		switch n.DataAtom {
-		case a.Script:
-			// if <script hoist>, hoist to the document root
-			if hasTruthyAttr(n, "hoist") {
-				doc.Scripts = append(doc.Scripts, n)
-				// Remove local script node
-				n.Parent.RemoveChild(n)
+	if n.Type == tycho.ElementNode && n.DataAtom == a.Script {
+		// if <script hoist>, hoist to the document root
+		if hasTruthyAttr(n, "hoist") {
+			doc.Scripts = append(doc.Scripts, n)
+		}
+	}
+}
+
+func AddComponentProps(doc *tycho.Node, n *tycho.Node) {
+	if n.Type == tycho.ElementNode && (n.Component || n.CustomElement) {
+		for _, attr := range n.Attr {
+			id := n.Data
+			if n.CustomElement {
+				id = fmt.Sprintf("'%s'", id)
 			}
-			// otherwise leave in place
-		default:
-			if n.Component || n.CustomElement {
-				for _, attr := range n.Attr {
-					id := n.Data
-					if n.CustomElement {
-						id = fmt.Sprintf("'%s'", id)
-					}
 
-					if strings.HasPrefix(attr.Key, "client:") {
-						doc.HydratedComponents = append(doc.HydratedComponents, n)
-						pathAttr := tycho.Attribute{
-							Key:  "client:component-path",
-							Val:  fmt.Sprintf("$$metadata.getPath(%s)", id),
-							Type: tycho.ExpressionAttribute,
-						}
-						n.Attr = append(n.Attr, pathAttr)
-
-						exportAttr := tycho.Attribute{
-							Key:  "client:component-export",
-							Val:  fmt.Sprintf("$$metadata.getExport(%s)", id),
-							Type: tycho.ExpressionAttribute,
-						}
-						n.Attr = append(n.Attr, exportAttr)
-						break
-					}
+			if strings.HasPrefix(attr.Key, "client:") {
+				doc.HydratedComponents = append(doc.HydratedComponents, n)
+				pathAttr := tycho.Attribute{
+					Key:  "client:component-path",
+					Val:  fmt.Sprintf("$$metadata.getPath(%s)", id),
+					Type: tycho.ExpressionAttribute,
 				}
+				n.Attr = append(n.Attr, pathAttr)
+
+				exportAttr := tycho.Attribute{
+					Key:  "client:component-export",
+					Val:  fmt.Sprintf("$$metadata.getExport(%s)", id),
+					Type: tycho.ExpressionAttribute,
+				}
+				n.Attr = append(n.Attr, exportAttr)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
## Changes

- Previously, scripts/styles that were siblings of each other appeared to only be processed up until the first script or style tag.  
- I assumed this was a tokenization or parser bug, but it was in our `transform` module!
- Previously, we would add a style to `doc.Styles` and immediately remove it from it's parent node. Doing this _during_ the recursive `walk` function corrupted the children, meaning following nodes would be left in place.
- The fix was to **not remove** hoisted `style` or `script` elements until **after** the `doc` was `walk`ed.

## Testing

Added a test

## Docs

Bug fix only
