### PR TITLE
Fix: `style` ordering

### DIFF
--- a/.changeset/quiet-dolphins-beam.md
+++ b/.changeset/quiet-dolphins-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix style/script ordering

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -658,7 +658,7 @@ import * as $$module2 from 'two';
 import * as $$module3 from 'custom-element';`,
 					`const name = 'world';`},
 				styles:   []string{},
-				metadata: `{ modules: [{ module: $$module1, specifier: 'one' }, { module: $$module2, specifier: 'two' }, { module: $$module3, specifier: 'custom-element' }], hydratedComponents: [One, Two, 'my-element'], hoisted: [] }`,
+				metadata: `{ modules: [{ module: $$module1, specifier: 'one' }, { module: $$module2, specifier: 'two' }, { module: $$module3, specifier: 'custom-element' }], hydratedComponents: ['my-element', Two, One], hoisted: [] }`,
 				code: `${$$renderComponent($$result,'One',One,{"client:load":true,"client:component-path":($$metadata.getPath(One)),"client:component-export":($$metadata.getExport(One))})}
 ${$$renderComponent($$result,'Two',Two,{"client:load":true,"client:component-path":($$metadata.getPath(Two)),"client:component-export":($$metadata.getExport(Two))})}
 ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"client:component-path":($$metadata.getPath('my-element')),"client:component-export":($$metadata.getExport('my-element'))})}`,
@@ -929,9 +929,9 @@ import * as $$module1 from 'react-bootstrap';`},
 <div />`,
 			want: want{
 				styles: []string{
-					"{props:{\"global\":true},children:`div { color: red }`}",
-					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
 					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:blue;}`}",
+					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
+					"{props:{\"global\":true},children:`div { color: red }`}",
 				},
 				code: "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
 			},

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -44,7 +44,8 @@ func ExtractStyles(doc *tycho.Node) {
 			if n.Parent != nil && n.Parent.DataAtom == atom.Svg {
 				return
 			}
-			doc.Styles = append(doc.Styles, n)
+			// prepend node to maintain authored order
+			doc.Styles = append([]*tycho.Node{n}, doc.Styles...)
 		}
 	})
 	// Important! Remove styles from original location *after* walking the doc
@@ -67,7 +68,8 @@ func ExtractScript(doc *tycho.Node, n *tycho.Node) {
 	if n.Type == tycho.ElementNode && n.DataAtom == a.Script {
 		// if <script hoist>, hoist to the document root
 		if hasTruthyAttr(n, "hoist") {
-			doc.Scripts = append(doc.Scripts, n)
+			// prepend node to maintain authored order
+			doc.Scripts = append([]*tycho.Node{n}, doc.Scripts...)
 		}
 	}
 }
@@ -81,7 +83,8 @@ func AddComponentProps(doc *tycho.Node, n *tycho.Node) {
 			}
 
 			if strings.HasPrefix(attr.Key, "client:") {
-				doc.HydratedComponents = append(doc.HydratedComponents, n)
+				// prepend node to maintain authored order
+				doc.HydratedComponents = append([]*tycho.Node{n}, doc.HydratedComponents...)
 				pathAttr := tycho.Attribute{
 					Key:  "client:component-path",
 					Val:  fmt.Sprintf("$$metadata.getPath(%s)", id),


### PR DESCRIPTION
## Changes

- Followup to https://github.com/snowpackjs/astro/pull/1721. 
- Rather than reverse the final order from the `astro` side, the correct fix is to reverse the order per-file in the compiler.

**Previously,** text was _red_.
<img width="845" alt="Screen Shot 2021-11-02 at 5 13 56 PM" src="https://user-images.githubusercontent.com/7118177/139959119-7c2adbdb-7c38-45c9-85d0-e2b57b12f3c2.png">

**With this change,** text is _yellow_.

## Testing

Tests updated, but not testing this specifically

## Docs

Bug fix only
