### PR TITLE
Preserve slots inside `<custom-element>`

### DIFF
--- a/.changeset/khaki-mails-remain.md
+++ b/.changeset/khaki-mails-remain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix custom-element slot behavior to remain spec compliant

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -364,6 +364,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				if !(n.Parent.Component || n.Parent.CustomElement) {
 					panic(`Element with a slot='...' attribute must be a child of a component or a descendant of a custom element`)
 				}
+				if n.Parent.CustomElement {
+					p.printAttribute(a)
+					p.addSourceMapping(n.Loc[0])
+				}
 			} else {
 				p.printAttribute(a)
 				p.addSourceMapping(n.Loc[0])
@@ -424,6 +428,19 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 		if !isAllWhiteSpace {
 			switch true {
+			case n.CustomElement:
+				p.print(`,{`)
+				p.print(fmt.Sprintf(`"%s": () => `, "default"))
+				p.printTemplateLiteralOpen()
+				for c := n.FirstChild; c != nil; c = c.NextSibling {
+					render1(p, c, RenderOptions{
+						isRoot:       false,
+						isExpression: opts.isExpression,
+						depth:        depth + 1,
+					})
+				}
+				p.printTemplateLiteralClose()
+				p.print(`,}`)
 			case isComponent:
 				p.print(`,{`)
 				slottedChildren := make(map[string][]*Node)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -964,6 +964,13 @@ import * as $$module1 from 'react-bootstrap';`},
 				code: `<html><head></head><body>${$$renderComponent($$result,'Component',Component,{},{"named": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{"slot":"named"},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body></html>`,
 			},
 		},
+		{
+			name:   "Preseve slots inside custom-element",
+			source: `<body><my-element><div slot=name>Name</div><div>Default</div></my-element></body>`,
+			want: want{
+				code: `<html><head></head><body>${$$renderComponent($$result,'my-element','my-element',{},{"default": () => $$render` + BACKTICK + `<div slot="name">Name</div><div>Default</div>` + BACKTICK + `,})}</body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

Fixes https://github.com/snowpackjs/astro/issues/1717.

Previously, we would compile all slots to use our custom Astro slot handling. For `custom-elements`, `slot` has different semantics and should be left up to the custom element itself.

This change passes through any slotted elements as written. 

## Testing

Test added

## Docs

Bug fix only
