### PR TITLE
fix: better handling for text inside of elements inside of expressions

### DIFF
--- a/.changeset/wet-crews-sin.md
+++ b/.changeset/wet-crews-sin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix apostrophe handling inside of elements which are inside of expressions ([#1478](https://github.com/snowpackjs/astro/issues/1478))

--- a/internal/token.go
+++ b/internal/token.go
@@ -1252,15 +1252,15 @@ func (z *Tokenizer) Loc() loc.Loc {
 	return loc.Loc{Start: z.raw.Start}
 }
 
-// When inside of an expression, this function is called to determine if the next token should be
-// treated agnostically (plain text, not JS) or as JS (_do_ handle comments, strings, etc)
-// This allows '"`/ chars inside of elements!
-func (z *Tokenizer) isAtTextBoundary() bool {
+// An expression boundary means the next tokens should be treated as a JS expression
+// (_do_ handle strings, comments, regexp, etc) rather than as plain text
+func (z *Tokenizer) isAtExpressionBoundary() bool {
 	prev := z.prevTokenType
 	if len(z.expressionStack) == 0 {
 		return false
 	}
 	switch prev {
+	// Inside of expressions, these tokens flag that the following tokens are plain text (not JS)
 	case StartTagToken, EndTagToken, SelfClosingTagToken, EndExpressionToken:
 		return false
 	}
@@ -1308,8 +1308,7 @@ func (z *Tokenizer) Next() TokenType {
 	if z.fm != FrontmatterClosed {
 		goto frontmatter_loop
 	}
-	// When inside an expression but after a StartTag, read next tokens as regular text rather than expression text
-	if z.isAtTextBoundary() {
+	if z.isAtExpressionBoundary() {
 		goto expression_loop
 	}
 

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -501,6 +501,21 @@ func TestExpressions(t *testing.T) {
 			`{true ? <div>Don't panic</div> : <div>Do' panic</div>}`,
 			[]TokenType{StartExpressionToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, StartTagToken, TextToken, EndTagToken, EndExpressionToken},
 		},
+		{
+			"single quote after expression",
+			`{true && <div>{value} Don't panic</div>}`,
+			[]TokenType{StartExpressionToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, TextToken, EndTagToken, EndExpressionToken},
+		},
+		{
+			"single quote after self-closing",
+			`{true && <div><span /> Don't panic</div>}`,
+			[]TokenType{StartExpressionToken, TextToken, StartTagToken, SelfClosingTagToken, TextToken, EndTagToken, EndExpressionToken},
+		},
+		{
+			"single quote after end tag",
+			`{true && <div><span></span> Don't panic</div>}`,
+			[]TokenType{StartExpressionToken, TextToken, StartTagToken, StartTagToken, EndTagToken, TextToken, EndTagToken, EndExpressionToken},
+		},
 	}
 
 	runTokenTypeTest(t, Expressions)


### PR DESCRIPTION
## Changes

- Followup to #122, which was an incomplete solution.
- This fixes handling of `'`, `"`, `` ` ``, and `/` character inside of elements that are inside of expressions.
- Closes https://github.com/snowpackjs/astro/issues/1478

## Testing

Tests added

## Docs

Bugfix only