### PR TITLE
Fix namespaced attribute printing

### DIFF
--- a/.changeset/tiny-ties-crash.md
+++ b/.changeset/tiny-ties-crash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix namespace handling to support attributes like `xmlns:xlink`

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -204,6 +204,10 @@ func (p *printer) printAttribute(attr astro.Attribute) {
 		return
 	}
 
+	if attr.Namespace != "" || attr.Type == astro.QuotedAttribute || attr.Type == astro.EmptyAttribute {
+		p.print(" ")
+	}
+
 	if attr.Namespace != "" {
 		p.print(attr.Namespace)
 		p.print(":")
@@ -211,14 +215,12 @@ func (p *printer) printAttribute(attr astro.Attribute) {
 
 	switch attr.Type {
 	case astro.QuotedAttribute:
-		p.print(" ")
 		p.addSourceMapping(attr.KeyLoc)
 		p.print(attr.Key)
 		p.print("=")
 		p.addSourceMapping(attr.ValLoc)
 		p.print(`"` + attr.Val + `"`)
 	case astro.EmptyAttribute:
-		p.print(" ")
 		p.addSourceMapping(attr.KeyLoc)
 		p.print(attr.Key)
 	case astro.ExpressionAttribute:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -993,10 +993,17 @@ import * as $$module1 from 'react-bootstrap';`},
 			},
 		},
 		{
-			name:   "Preseve slots inside custom-element",
+			name:   "Preserve slots inside custom-element",
 			source: `<body><my-element><div slot=name>Name</div><div>Default</div></my-element></body>`,
 			want: want{
 				code: `<html><head></head><body>${$$renderComponent($$result,'my-element','my-element',{},{"default": () => $$render` + BACKTICK + `<div slot="name">Name</div><div>Default</div>` + BACKTICK + `,})}</body></html>`,
+			},
+		},
+		{
+			name:   "Preserve namespaces",
+			source: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></svg>`,
+			want: want{
+				code: `<html><head></head><body><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></rect></svg></body></html>`,
 			},
 		},
 	}


### PR DESCRIPTION
## Changes

- We had a bug in our `printAttribute` function that would print namespaced attributes in an invalid way. 
- This is fixed, unblocking attributes like `xmlnm:xlink`

## Testing

Test added

## Docs

Bug fix only
