### PR TITLE
fix: script hoist behavior

### DIFF
--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -105,6 +105,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 	// Render frontmatter (will be the first node, if it exists)
 	if n.Type == FrontmatterNode {
+		fmt.Println("FrontmatterNode")
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
 				p.printInternalImports(p.opts.InternalURL)
@@ -114,9 +115,13 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				// `renderBodyStart` will be the index where we should split the frontmatter.
 				// If we don't encounter any of those, `renderBodyStart` will be `-1`
 				renderBodyStart := js_scanner.FindRenderBody([]byte(c.Data))
-				p.addSourceMapping(n.Loc[0])
+				if len(n.Loc) > 0 {
+					p.addSourceMapping(n.Loc[0])
+				}
 				if renderBodyStart == -1 {
-					p.addSourceMapping(c.Loc[0])
+					if len(c.Loc) > 0 {
+						p.addSourceMapping(c.Loc[0])
+					}
 					if js_scanner.AccessesPrivateVars([]byte(c.Data)) {
 						panic(errors.New("Variables prefixed by \"$$\" are reserved for Astro's internal usage!"))
 					}
@@ -142,7 +147,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					//  {
 					// 	panic(errors.New("Variables prefixed by \"$$\" are reserved for Astro's internal usage!"))
 					// }
-					p.addSourceMapping(c.Loc[0])
+					if len(c.Loc) > 0 {
+						p.addSourceMapping(c.Loc[0])
+					}
 					p.println(strings.TrimSpace(importStatements))
 
 					// 1. Component imports, if any exist.
@@ -152,7 +159,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 					// TODO: use the proper component name
 					p.printFuncPrelude("$$Component")
-					p.addSourceMapping(loc.Loc{Start: c.Loc[0].Start + renderBodyStart})
+					if len(c.Loc) > 0 {
+						p.addSourceMapping(loc.Loc{Start: c.Loc[0].Start + renderBodyStart})
+					}
 					p.print(strings.TrimSpace(renderBody))
 				}
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -5,6 +5,7 @@
 package printer
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -117,7 +118,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					p.addSourceMapping(n.Loc[0])
 				}
 				if renderBodyStart == -1 {
-          if len(c.Loc) > 0 {
+					if len(c.Loc) > 0 {
 						p.addSourceMapping(c.Loc[0])
 					}
 					preprocessed := js_scanner.HoistExports([]byte(c.Data))
@@ -143,13 +144,11 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					importStatements := c.Data[0:renderBodyStart]
 					content := c.Data[renderBodyStart:]
 					preprocessed := js_scanner.HoistExports([]byte(content))
+					renderBody := preprocessed.Body
 
-					if js_scanner.HasExports([]byte(renderBody)) {
+					if js_scanner.HasExports(renderBody) {
 						panic(errors.New("Export statements must be placed at the top of .astro files!"))
 					}
-					//  {
-					// 	panic(errors.New("Variables prefixed by \"$$\" are reserved for Astro's internal usage!"))
-					// }
 					if len(c.Loc) > 0 {
 						p.addSourceMapping(c.Loc[0])
 					}
@@ -171,7 +170,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					if len(c.Loc) > 0 {
 						p.addSourceMapping(loc.Loc{Start: c.Loc[0].Start + renderBodyStart})
 					}
-          p.print(strings.TrimSpace(string(preprocessed.Body)))
+					p.print(strings.TrimSpace(string(preprocessed.Body)))
 				}
 
 				// Print empty just to ensure a newline

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -105,7 +105,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 	// Render frontmatter (will be the first node, if it exists)
 	if n.Type == FrontmatterNode {
-		fmt.Println("FrontmatterNode")
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
 				p.printInternalImports(p.opts.InternalURL)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -366,7 +366,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, source []byte) {
 		if src != nil {
 			p.print(fmt.Sprintf("{ type: 'remote', src: '%s' }", escapeSingleQuote(src.Val)))
 		} else if node.FirstChild != nil {
-			p.print(fmt.Sprintf("{ type: 'inline', value: '%s' }", escapeSingleQuote(node.FirstChild.Data)))
+			p.print(fmt.Sprintf("{ type: 'inline', value: `%s` }", escapeInterpolation(escapeBackticks(node.FirstChild.Data))))
 		}
 	}
 	p.print("] });\n\n")

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -565,7 +565,7 @@ import * as $$module2 from '../components/Widget2.astro';`},
 				frontmatter: []string{""},
 				styles:      []string{},
 				scripts:     []string{fmt.Sprintf(`{props:{"type":"module","hoist":true},children:%sconsole.log("Hello");%s}`, BACKTICK, BACKTICK)},
-				metadata:    metadata{hoisted: []string{`{ type: 'inline', value: 'console.log("Hello");' }`}},
+				metadata:    metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
 				code:        `<html><head></head><body></body></html>`,
 			},
 		},
@@ -591,7 +591,7 @@ import * as $$module2 from '../components/Widget2.astro';`},
 			want: want{
 				styles:   []string{},
 				scripts:  []string{"{props:{\"type\":\"module\",\"hoist\":true},children:`console.log(\"Hello\");`}"},
-				metadata: metadata{hoisted: []string{`{ type: 'inline', value: 'console.log("Hello");' }`}},
+				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
 				code: `<html><head></head><body><main>
 
 </main></body></html>`,

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	astro "github.com/snowpackjs/astro/internal"
 	tycho "github.com/snowpackjs/astro/internal"
 	"golang.org/x/net/html/atom"
 	a "golang.org/x/net/html/atom"
@@ -32,6 +33,19 @@ func Transform(doc *tycho.Node, opts TransformOptions) *tycho.Node {
 	// Important! Remove scripts from original location *after* walking the doc
 	for _, script := range doc.Scripts {
 		script.Parent.RemoveChild(script)
+	}
+
+	// If we've emptied out all the nodes, this was a Fragment that only contained hoisted elements
+	// Add an empty FrontmatterNode to allow the empty component to be printed
+	if doc.FirstChild == nil {
+		empty := &astro.Node{
+			Type: astro.FrontmatterNode,
+		}
+		empty.AppendChild(&astro.Node{
+			Type: astro.TextNode,
+			Data: "",
+		})
+		doc.AppendChild(empty)
 	}
 
 	return doc


### PR DESCRIPTION
## Changes

See https://github.com/snowpackjs/astro/pull/1743

- When a component only included `<script hoist>`, we would print malformed JS because the `doc` was empty when we tried to print it.
- Now, if we hoist out all the contents, we inject an empty `FrontmatterNode` with an empty `TextNode` child.
- This allows the `printToJs` function to keep doing it's thing and returns valid JS.

## Testing

This is not tested because it is a difficult edge case to test for with our current setup

## Docs

Bug fix
