### PR TITLE
Improved handling for unreachable errors

### DIFF
--- a/.changeset/two-dragons-nail.md
+++ b/.changeset/two-dragons-nail.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improve `unreachable` errors by pointing users directly to GitHub

--- a/lib/compiler/node/index.ts
+++ b/lib/compiler/node/index.ts
@@ -4,7 +4,27 @@ import Go from './wasm_exec.js';
 import { fileURLToPath } from 'url';
 
 export const transform: typeof types.transform = async (input, options) => {
-  return ensureServiceIsRunning().then((service) => service.transform(input, options));
+  return ensureServiceIsRunning()
+    .then((service) => service.transform(input, options))
+    .catch((err) => {
+      if (err.toString().includes('unreachable')) {
+        const title = '🐛 BUG: `@astrojs/compiler` panic';
+        const filename = options?.sourcefile ? `**root/src/${options?.sourcefile.split('/src/')[2]}**` : '';
+        const body = `### Describe the Bug
+
+\`@astrojs/compiler\` encountered an unrecoverable error when compiling the following file.
+
+${filename}
+\`\`\`astro\n${input}\n\`\`\`
+`;
+        const url = `https://github.com/snowpackjs/astro/issues/new?labels=compiler&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+        throw new Error(`Uh oh, the Astro compiler encountered an unrecoverable error!
+        
+Please open a GitHub issue using the link below:
+${url}`);
+      }
+      throw err;
+    });
 };
 
 export const compile = async (template: string): Promise<string> => {

--- a/lib/compiler/node/index.ts
+++ b/lib/compiler/node/index.ts
@@ -8,20 +8,8 @@ export const transform: typeof types.transform = async (input, options) => {
     .then((service) => service.transform(input, options))
     .catch((err) => {
       if (err.toString().includes('unreachable')) {
-        const title = '🐛 BUG: `@astrojs/compiler` panic';
-        const filename = options?.sourcefile ? `**root/src/${options?.sourcefile.split('/src/')[2]}**` : '';
-        const body = `### Describe the Bug
-
-\`@astrojs/compiler\` encountered an unrecoverable error when compiling the following file.
-
-${filename}
-\`\`\`astro\n${input}\n\`\`\`
-`;
-        const url = `https://github.com/snowpackjs/astro/issues/new?labels=compiler&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
-        throw new Error(`Uh oh, the Astro compiler encountered an unrecoverable error!
-        
-Please open a GitHub issue using the link below:
-${url}`);
+        throw new Error(`The Astro compiler encountered a SyntaxError!
+${options?.sourcefile ?? ''}`);
       }
       throw err;
     });

--- a/lib/compiler/test/error.test.mjs
+++ b/lib/compiler/test/error.test.mjs
@@ -1,0 +1,30 @@
+import { transform } from '@astrojs/compiler';
+
+async function run() {
+  try {
+    await transform(
+      `{metaInfo.map((array) => <dl>
+        {Object.entries(array).map((info) => <<<<<<<>>>>>
+            <dt>{info[0]}</dt>
+            <dd>{info[1]}</dd>
+        </>)}
+    </dl>)}`,
+      {
+        as: 'fragment',
+        site: undefined,
+        sourcefile: `${process.cwd()}/src/pages/namespaced.astro`,
+        sourcemap: 'both',
+        internalURL: 'astro/internal',
+        preprocessStyle: async (value, attrs) => {
+          return null;
+        },
+      }
+    );
+  } catch (e) {
+    if (!e.toString().includes('GitHub issue')) {
+      throw e;
+    }
+  }
+}
+
+await run();

--- a/lib/compiler/test/error.test.mjs
+++ b/lib/compiler/test/error.test.mjs
@@ -21,7 +21,7 @@ async function run() {
       }
     );
   } catch (e) {
-    if (!e.toString().includes('GitHub issue')) {
+    if (!e.toString().includes('SyntaxError')) {
       throw e;
     }
   }

--- a/lib/compiler/test/test.mjs
+++ b/lib/compiler/test/test.mjs
@@ -1,2 +1,3 @@
 import './basic.test.mjs';
 import './output.test.mjs';
+import './error.test.mjs';

--- a/lib/compiler/test/visible.test.mjs
+++ b/lib/compiler/test/visible.test.mjs
@@ -16,7 +16,6 @@ async function run() {
       <ThemeToggleButton client:visible />
     </div>`,
     {
-      sourcemap: true,
       as: 'fragment',
       site: undefined,
       sourcefile: 'MoreMenu.astro',


### PR DESCRIPTION
## Changes

- Previously, our compiler would occasionally throw `panic: unreachable` errors.
- It still does, but now there's a much more actionable error message.

```
Error: Uh oh, the Astro compiler encountered an unrecoverable error!
        
Please open a GitHub issue using the link below:
https://github.com/snowpackjs/astro/issues/new?labels=compiler&title=%F0%9F%90%9B%20BUG%3A%20%60%40astrojs%2Fcompiler%60%20panic&body=%23%23%23%20Describe%20the%20Bug%0A%0A%60%40astrojs%2Fcompiler%60%20encountered%20an%20unrecoverable%20error%20when%20compiling%20the%20following%20file.%0A%0A**root%2Fsrc%2Fpages%2Fnamespaced.astro**%0A%60%60%60astro%0A%7BmetaInfo.map((array)%20%3D%3E%20%3Cdl%3E%0A%20%20%20%20%20%20%20%20%7BObject.entries(array).map((info)%20%3D%3E%20%3C%3C%3C%3C%3C%3C%3C%3E%3E%3E%3E%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdt%3E%7Binfo%5B0%5D%7D%3C%2Fdt%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdd%3E%7Binfo%5B1%5D%7D%3C%2Fdd%3E%0A%20%20%20%20%20%20%20%20%3C%2F%3E)%7D%0A%20%20%20%20%3C%2Fdl%3E)%7D%0A%60%60%60%0A
```

Here is a [preview of the link contents](https://github.com/snowpackjs/astro/issues/new?labels=compiler&title=%F0%9F%90%9B%20BUG%3A%20%60%40astrojs%2Fcompiler%60%20panic&body=%23%23%23%20Describe%20the%20Bug%0A%0A%60%40astrojs%2Fcompiler%60%20encountered%20an%20unrecoverable%20error%20when%20compiling%20the%20following%20file.%0A%0A**root%2Fsrc%2Fpages%2Fnamespaced.astro**%0A%60%60%60astro%0A%7BmetaInfo.map((array)%20%3D%3E%20%3Cdl%3E%0A%20%20%20%20%20%20%20%20%7BObject.entries(array).map((info)%20%3D%3E%20%3C%3C%3C%3C%3C%3C%3C%3E%3E%3E%3E%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdt%3E%7Binfo%5B0%5D%7D%3C%2Fdt%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdd%3E%7Binfo%5B1%5D%7D%3C%2Fdd%3E%0A%20%20%20%20%20%20%20%20%3C%2F%3E)%7D%0A%20%20%20%20%3C%2Fdl%3E)%7D%0A%60%60%60%0A).

## Testing

WASM test added

## Docs

N/A