### PR TITLE
feat: use `$$metadata.resolvePath` to support `client:only` directive

### DIFF
--- a/.changeset/nervous-cycles-remain.md
+++ b/.changeset/nervous-cycles-remain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Use `$$metadata.resolvePath` utility to support the `client:only` directive

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -279,8 +279,8 @@ func (p *printer) printComponentMetadata(doc *astro.Node, source []byte) {
 						// Inject metadata attributes to `client:only` Component
 						pathAttr := astro.Attribute{
 							Key:  "client:component-path",
-							Val:  statement.Specifier,
-							Type: astro.QuotedAttribute,
+							Val:  fmt.Sprintf(`$$metadata.resolvePath("%s")`, statement.Specifier),
+							Type: astro.ExpressionAttribute,
 						}
 						n.Attr = append(n.Attr, pathAttr)
 
@@ -298,8 +298,8 @@ func (p *printer) printComponentMetadata(doc *astro.Node, source []byte) {
 					// Inject metadata attributes to `client:only` Component
 					pathAttr := astro.Attribute{
 						Key:  "client:component-path",
-						Val:  statement.Specifier,
-						Type: astro.QuotedAttribute,
+						Val:  fmt.Sprintf(`$$metadata.resolvePath("%s")`, statement.Specifier),
+						Type: astro.ExpressionAttribute,
 					}
 					n.Attr = append(n.Attr, pathAttr)
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -218,7 +218,7 @@ import Component from '../components';
     <title>Hello world</title>
   </head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true,"client:component-path":"../components","client:component-export":"default"})}
+    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true,"client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
   </body></html>`,
 			},
 		},
@@ -243,7 +243,7 @@ import { Component } from '../components';
     <title>Hello world</title>
   </head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true,"client:component-path":"../components","client:component-export":"Component"})}
+    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true,"client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"Component"})}
   </body></html>`,
 			},
 		},
@@ -268,7 +268,7 @@ import * as components from '../components';
     <title>Hello world</title>
   </head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'components.A',null,{"client:only":true,"client:component-path":"../components","client:component-export":"A"})}
+    ${` + RENDER_COMPONENT + `($$result,'components.A',null,{"client:only":true,"client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"A"})}
   </body></html>`,
 			},
 		},


### PR DESCRIPTION
## Changes

- Adds `$$metadata.resolvePath()` to `client:only` components.
- Needed to unblock https://github.com/snowpackjs/astro/pull/1716

## Testing

Tests updated

## Docs

N/A, internal implementation
