### PR TITLE
fix: drop JSX/TSX support from Frontmatter

### DIFF
--- a/.changeset/short-points-report.md
+++ b/.changeset/short-points-report.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Drop support for elements inside of Frontmatter, which was undefined behavior that caused lots of TypeScript interop problems

--- a/internal/token.go
+++ b/internal/token.go
@@ -1350,6 +1350,10 @@ loop:
 		if c != '<' {
 			continue loop
 		}
+		if z.fm == FrontmatterOpen {
+			z.raw.End--
+			goto frontmatter_loop
+		}
 
 		// Check if the '<' we have just read is part of a tag, comment
 		// or doctype. If not, it's part of the accumulated text token.
@@ -1524,8 +1528,13 @@ frontmatter_loop:
 
 		if s == '<' || s == '{' || s == '}' || c == '<' || c == '{' || c == '}' {
 			z.dashCount = 0
-			z.raw.End--
-			goto loop
+			if z.fm == FrontmatterOpen && (s == '<' || c == '<') {
+				// Do not support elements inside of frontmatter!
+				continue frontmatter_loop
+			} else {
+				z.raw.End--
+				goto loop
+			}
 		}
 
 		// handle string

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -265,23 +265,23 @@ func TestFrontmatter(t *testing.T) {
 			[]TokenType{FrontmatterFenceToken, TextToken, FrontmatterFenceToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken},
 		},
 		{
-			"tokenizes elements inside",
+			"does not tokenize elements inside",
 			`
 			---
 			const a = <div />;
 			---
 			`,
-			[]TokenType{FrontmatterFenceToken, TextToken, SelfClosingTagToken, TextToken, FrontmatterFenceToken},
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, FrontmatterFenceToken},
 		},
 		{
-			"elements can have expression as child in frontmatter",
+			"no elements or expressions in frontmatter",
 			`
 			---
 			const contents = "foo";
 			const a = <div>{contents}</div>;
 			---
 			`,
-			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, FrontmatterFenceToken},
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, FrontmatterFenceToken},
 		},
 		{
 			"brackets within frontmatter treated as text",
@@ -295,7 +295,7 @@ func TestFrontmatter(t *testing.T) {
 			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, TextToken, TextToken, TextToken, FrontmatterFenceToken},
 		},
 		{
-			"brackets within tags treated as expressions while brackets in frontmatter treated as text",
+			"frontmatter tags and brackets all treated as text",
 			`
 			---
 			const contents = "foo";
@@ -305,7 +305,7 @@ func TestFrontmatter(t *testing.T) {
 			}
 			---
 			`,
-			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, TextToken, FrontmatterFenceToken},
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, FrontmatterFenceToken},
 		},
 		{
 			"less than isn’t a tag",


### PR DESCRIPTION
## Changes

- This ended up being a pretty small change in the tokenizer, basically to ignore the current logic that any `<` characters should start an element.
- Didn't remove any logic from the parser/renderer that might handle this case. Those are dead code paths now, can cleanup later.

## Testing

Existing tests updated to reflect our new approach

## Docs

N/A
