### PR TITLE
Remove metadata type

### DIFF
--- a/.changeset/new-weeks-mix.md
+++ b/.changeset/new-weeks-mix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix for compiler regression causing nil pointer

--- a/internal/node.go
+++ b/internal/node.go
@@ -54,8 +54,9 @@ type Node struct {
 	Parent, FirstChild, LastChild, PrevSibling, NextSibling *Node
 
 	// These are only accessible from the document root Node
-	Styles, Scripts []*Node
-	Metadata        *Metadata
+	Styles, Scripts      []*Node
+	HydratedComponents   []*Node
+	ClientOnlyComponents []*Node
 
 	Type      NodeType
 	DataAtom  atom.Atom
@@ -63,13 +64,6 @@ type Node struct {
 	Namespace string
 	Attr      []Attribute
 	Loc       []loc.Loc
-}
-
-// Metadata is a collection of anything that needs to be hoisted out of the
-// template layer, as well as any additional info needed to render the component.
-type Metadata struct {
-	HydratedComponents   []*Node
-	ClientOnlyComponents []*Node
 }
 
 // InsertBefore inserts newChild as a child of n, immediately before oldChild

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2725,8 +2725,7 @@ func ParseWithOptions(r io.Reader, opts ...ParseOption) (*Node, error) {
 	p := &parser{
 		tokenizer: NewTokenizer(r),
 		doc: &Node{
-			Type:     DocumentNode,
-			Metadata: &Metadata{},
+			Type: DocumentNode,
 		},
 		scripting:        true,
 		framesetOK:       true,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -268,7 +268,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, source []byte) {
 	loc, statement := js_scanner.NextImportStatement(source, 0)
 	for loc != -1 {
 		isClientOnlyImport := false
-		for _, n := range doc.Metadata.ClientOnlyComponents {
+		for _, n := range doc.ClientOnlyComponents {
 			for _, imported := range statement.Imports {
 				if imported.ExportName == "*" {
 					prefix := fmt.Sprintf("%s.", imported.LocalName)
@@ -345,7 +345,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, source []byte) {
 
 	// Hydrated Components
 	p.print(", hydratedComponents: [")
-	for i, node := range doc.Metadata.HydratedComponents {
+	for i, node := range doc.HydratedComponents {
 		if i > 0 {
 			p.print(", ")
 		}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -98,11 +98,11 @@ func AddComponentProps(doc *tycho.Node, n *tycho.Node) {
 
 			if strings.HasPrefix(attr.Key, "client:") {
 				if attr.Key == "client:only" {
-					doc.Metadata.ClientOnlyComponents = append([]*tycho.Node{n}, doc.Metadata.ClientOnlyComponents...)
+					doc.ClientOnlyComponents = append([]*tycho.Node{n}, doc.ClientOnlyComponents...)
 					break
 				}
 				// prepend node to maintain authored order
-				doc.Metadata.HydratedComponents = append([]*tycho.Node{n}, doc.Metadata.HydratedComponents...)
+				doc.HydratedComponents = append([]*tycho.Node{n}, doc.HydratedComponents...)
 				pathAttr := tycho.Attribute{
 					Key:  "client:component-path",
 					Val:  fmt.Sprintf("$$metadata.getPath(%s)", id),


### PR DESCRIPTION
## Changes

- In https://github.com/snowpackjs/astro-compiler-next/pull/146 I make the `Metadata` type a pointer in order to fix the `\x00` issue, however since this object is checked in the printer it needs to be initialized. This would mean ever time we create a Node (which happens all over in the parser) we would also need to create a Metadata.
- Instead this moves those slices back onto the top-level Node object, to prevent this.

## Testing

Tests in Astro are broken, no idea why these tests are passing. Probably a wasm specific issue.

## Docs

N/A