### PR TITLE
fix: comments and strings inside of expression attributes

### DIFF
--- a/.changeset/new-socks-punch.md
+++ b/.changeset/new-socks-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix comments and strings inside of attribute expressions

--- a/internal/token.go
+++ b/internal/token.go
@@ -787,28 +787,6 @@ find_next:
 }
 
 // read RegExp expressions and comments (starting from '/' byte)
-func (z *Tokenizer) readMultilineCommentOrRegExp() {
-	c := z.readByte() // find next character after '/' to know how to handle it
-	switch c {
-	// multi-line comment
-	case '*':
-		// look for "*/"
-		for {
-			z.readUntilChar([]byte{'*'})
-			c = z.readByte()
-			if c == '/' {
-				z.data.End = z.raw.End
-				return
-			}
-		}
-	// RegExp
-	default:
-		z.raw.End--
-		z.readUntilChar([]byte{'/', '\r', '\n'})
-	}
-}
-
-// read RegExp expressions and comments (starting from '/' byte)
 func (z *Tokenizer) readCommentOrRegExp() {
 	c := z.readByte() // find next character after '/' to know how to handle it
 	switch c {

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -123,6 +123,21 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 		{
+			"attribute expression with quoted braces",
+			`<div value={"{"} />`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
+			"attribute expression with quote",
+			`<div value={/* hello */} />`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
+			"JSX-style comment inside element",
+			`<div {/* hello */} a=b />`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
 			"quotes within textContent",
 			`<p>can't</p>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
@@ -182,8 +197,6 @@ func TestBasic(t *testing.T) {
 			`<Fragment>foo</Fragment>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
-		// Special Case: this should PANIC! Not sure how to test for a panic
-
 	}
 
 	runTokenTypeTest(t, Basic)
@@ -200,6 +213,11 @@ To fix this, please change
   < slot="named">
 to use the longhand Fragment syntax:
   <Fragment slot="named">`,
+		},
+		{
+			"block comment in attribute",
+			`<div {// uhh} />`,
+			`Block comments (//) are not allowed inside of expressions`,
 		},
 	}
 	runPanicTest(t, Panics)
@@ -572,6 +590,11 @@ func TestAttributes(t *testing.T) {
 			"multiple quoted",
 			`<div a="value" b='value' c=value/>`,
 			[]AttributeType{QuotedAttribute, QuotedAttribute, QuotedAttribute},
+		},
+		{
+			"expression with quoted braces",
+			`<div value={ "{" } />`,
+			[]AttributeType{ExpressionAttribute},
 		},
 	}
 


### PR DESCRIPTION
Supersedes https://github.com/snowpackjs/astro/issues/1833

## Changes

- Previously, comments and strings weren't being handled inside of expression attributes
- We also weren't able to support comments inside of a tag, but now we can (because they're expression attributes)

## Testing

Tokenizer tests added

## Docs

Bug fix