### PR TITLE
Revert "Upgrade go to 1.17 (#104)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.16
 
       - name: Test
         run: go test -v ./internal/...
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.16
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.16
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome to the Go compiler!
 
 ### Go
 
-[Go][go] `1.17.x` is needed to work with this repo. On Macs, installing via [Homebrew][homebrew] is recommended: `brew install go`. For Windows & Linux, you can [follow Go’s installation guide][go] if you don’t have your own preferred method of package installation.
+[Go][go] `1.16.x` is needed to work with this repo. On Macs, installing via [Homebrew][homebrew] is recommended: `brew install go@1.16`. For Windows & Linux, you can [follow Go’s installation guide][go] if you don’t have your own preferred method of package installation.
 
 By default, Go will set `$GOPATH` to a new `./go/` directory in your home folder. For best support with VS Code and tooling, it’s recommended to place Go projects like this one in here. So for this project, that would mean cloning it to `~/go/src/github.com/snowpackjs/astro-compiler-next`. You can change this path, but it does require some understanding. Read [Understanding the GOPATH][gopath] to learn more.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snowpackjs/astro
 
-go 1.17
+go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.6


### PR DESCRIPTION
This reverts commit 83df04cc544be24f40c3debd202c0c753c3f8edb.

## Changes

- Downgrades Go to 1.16. 1.17 causes failures on OSX due to parts of the app from not compiling correctly.

## Testing

N/A

## Docs

N/A
