### PR TITLE
Fix leading `style` and `script hoist`

### DIFF
--- a/.changeset/heavy-masks-jump.md
+++ b/.changeset/heavy-masks-jump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of top-level component nodes with leading styles

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -825,9 +825,22 @@ func inHeadIM(p *parser) bool {
 			p.templateStack = append(p.templateStack, inTemplateIM)
 			return true
 		}
+
+		if p.oe.top() != nil && (isComponent(p.oe.top().Data) || isFragment((p.oe.top().Data))) {
+			p.addElement()
+			p.setOriginalIM()
+			p.im = inBodyIM
+			if p.hasSelfClosingToken {
+				p.addLoc()
+				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
+			}
+			return true
+		}
 	case EndTagToken:
 		if isComponent(p.tok.Data) || isFragment(p.tok.Data) {
-			p.addElement()
+			p.addLoc()
+			p.oe.pop()
 			return true
 		}
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -44,7 +44,7 @@ func Transform(doc *tycho.Node, opts TransformOptions) *tycho.Node {
 		walk(doc, func(n *tycho.Node) {
 			if n.Component && n.Parent != nil && n.Parent.DataAtom == a.Head {
 				onlyComponent = n
-			} else if hasBody == false && n.DataAtom == a.Body {
+			} else if !hasBody && n.DataAtom == a.Body {
 				hasBody = true
 			}
 		})

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -35,6 +35,27 @@ func Transform(doc *tycho.Node, opts TransformOptions) *tycho.Node {
 		script.Parent.RemoveChild(script)
 	}
 
+	// Sometimes files have leading <script hoist> or <style>...
+	// Since we can't detect a "component-only" file until after `parse`, we need to handle
+	// them here. The component will be hoisted to the root of the document, `html` and `head` will be removed.
+	if opts.As != "Fragment" {
+		hasBody := false
+		var onlyComponent *tycho.Node
+		walk(doc, func(n *tycho.Node) {
+			if n.Component && n.Parent != nil && n.Parent.DataAtom == a.Head {
+				onlyComponent = n
+			} else if hasBody == false && n.DataAtom == a.Body {
+				hasBody = true
+			}
+		})
+
+		if !hasBody && onlyComponent != nil {
+			onlyComponent.Parent.RemoveChild(onlyComponent)
+			doc.AppendChild(onlyComponent)
+			doc.RemoveChild(onlyComponent.PrevSibling)
+		}
+	}
+
 	// If we've emptied out all the nodes, this was a Fragment that only contained hoisted elements
 	// Add an empty FrontmatterNode to allow the empty component to be printed
 	if doc.FirstChild == nil {


### PR DESCRIPTION
## Changes

- In most cases, our parser is smart enough to detect when the only element is a `Component` node and skip generating the implied `html`, `head`, and `body` tags. This happens if the `Component` comes first.
- If there is a `style` or `script hoist` tag above the `Component` node, our parser isn't able to lookahead and determine if `html`, `head`, and `body` should be generated. They always are. 
- This PR adds a `transform` step that corrects the parser output. This happens here because this is the step where we walk the document and make any mutations based on contextual information.

## Testing

New test suite added to `transform`

## Docs

Bug fix
